### PR TITLE
Feature/generalization of rayon oblast concept

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,8 +1,7 @@
 name: Bug Report
 description: Report a bug in the project
 title: "[BUG] "
-labels: bugsudo apt-get install -y libgdal-dev gdal-bin python3-gdal
-assignees: ''
+labels: bug
 
 body:
   - type: markdown
@@ -32,7 +31,6 @@ body:
     attributes:
       label: Screenshots or logs
       description: Provide screenshots or log output to help us diagnose the issue.
-  - type: dropdown
   - type: textarea
     attributes:
       label: Additional context

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -2,7 +2,6 @@ name: Feature Request
 description: Propose a new feature or enhancement
 title: "[FEATURE] "
 labels: enhancement
-assignees: ''
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,31 @@
+name: General
+description: Ask a question, seek help, or discuss a topic
+title: "[GENERAL] "
+labels: question, discussion
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question, need help, or want to discuss something? Please provide as much information as possible to help us assist you.
+  - type: textarea
+    attributes:
+      label: Your question or topic
+      description: What is your question, issue, or topic for discussion?
+      placeholder: "What do you need help with or want to discuss?"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Context or background
+      description: Provide any relevant background information or context.
+      placeholder: "Describe the context..."
+  - type: textarea
+    attributes:
+      label: What have you tried or considered?
+      description: Let us know what you've already tried or considered to resolve the issue or approach the topic.
+      placeholder: "Details of attempts, research, or considerations..."
+  - type: textarea
+    attributes:
+      label: Additional details or resources
+      description: Add any other details, screenshots, links, or resources related to your question or topic.

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ To manipulate json files via the command line, install https://jqlang.github.io/
 ## Convert Shapefile to GeoJSONs (one-time)
 If you have a shapefile, extract each of the geospatial polygons into an individual geojson. This also sets up a directory tree with each geospatial polygon as its own folder (prepping for parallel execution of all regions). You need to do this for each year and timepoint you want to run.
 
+Ensure your shapefile attribute data contains a column for the administrative division name (region) called "admin_name". The file is only allowed to contain entries that specify geometries for this administrative level. You can also use the `prepare_shapefile.py` script to preprocess your shapefile to follow these conventions. If using the script ensure you use the newly created file from the script in the following steps. We recommend to additionally manually ensure that your shapefile does not mix entries from different administrative levels.
+
 ```
 mkdir -p ~/Data/vercye_ops/Ukraine_Admin_Units/simstudy_20240607/2021/T-0
 
-# Set the `admin_level` to "oblast" or "raion" if there are two levels in the shapefile
 python ~/Builds/vercye_ops/vercye_ops/apsim/convert_shapefile_to_geojson.py \
 --shp_fpath /path/to/UKR_adm1.shp \
---admin_level oblast
 --output_head_dir ~/Data/vercye_ops/Ukraine_Admin_Units/simstudy_20240607/2021/T-0 \
 --verbose
 ```

--- a/vercye_ops/apsim/convert_shapefile_to_geojson.py
+++ b/vercye_ops/apsim/convert_shapefile_to_geojson.py
@@ -56,16 +56,17 @@ def convert_shapefile_to_geojson(shp_fpath, projection_epsg, output_head_dir):
     logger.info('Processing %i %s regions.', len(gdf))
 
     # Validate that only a single administrative division name column is present
-    if not 'NAME_1' in gdf.columns:
-        raise ValueError('The shapefile does not contain a "NAME_1" column. Please ensure that the administrative division name is stored in a column named "NAME_1".')
-
-    if 'NAME_2' in gdf.columns or 'NAME_3' in gdf.columns:
-        raise ValueError('Warning: The shapefile contains multiple administrative division name columns (e.g "Name_2", "Name_3"). Ensure that only a single name column called "NAME_1" is present.')
+    if not 'admin_name' in gdf.columns:
+        raise ValueError(
+            '''The shapefile is missing the "admin_name" column. Ensure the column 
+            contains administrative division names. Use the "prepare_shapefile.py" 
+            script to standardize the shapefile with correct column names.'''
+        )
 
     # Iterate over the GeoDataFrame rows, saving each to geojson
     for _, row in gdf.iterrows():
-        
-        region_name = row['NAME_1']
+
+        region_name = row['admin_name']
 
         # Take out any apostrophes as these cause headaches down the line with scripting the filename processing
         region_name = region_name.replace("'", "")

--- a/vercye_ops/apsim/fetch_met_data.py
+++ b/vercye_ops/apsim/fetch_met_data.py
@@ -1,19 +1,11 @@
 """CLI tools for fetching/formatting meteorological data"""
 
-import os
 import os.path as op
 from pathlib import Path
 
 import click
-import ftplib
-import geopandas as gpd
-import numpy as np
-import pandas as pd
-import rasterio
-from rasterio.mask import mask
-from rasterio.transform import rowcol
 import requests
-
+import pandas as pd
 
 from vercye_ops.utils.init_logger import get_logger
 
@@ -73,11 +65,16 @@ def error_checking_function(df):
     return df
 
 
-def fetch_nasa_power_data(start_date, end_date, variables, lon, lat):
+def fetch_nasa_power_data(start_date, end_date, variables, lon, lat, output_dir, overwrite):
     """
     Fetches weather data from the NASA POWER API for a given latitude and longitude between start_date and end_date,
-    for the desired variables.
+    for the desired variables, and writes it to a CSV after processing.
     """
+    region = Path(output_dir).stem
+    output_fpath = op.join(output_dir, f'{region}_nasapower.csv')
+    if Path(output_fpath).exists and not overwrite:
+        logger.info("Weather data already exists locally. Skipping: \n%s", output_fpath)
+        return
 
     logger.info("Fetching data from NASA POWER for %s to %s...", start_date.date(), end_date.date())
 
@@ -109,168 +106,10 @@ def fetch_nasa_power_data(start_date, end_date, variables, lon, lat):
     # TODO: Flesh out required checks
     df_cleaned = error_checking_function(df)
 
-    return df_cleaned
-
-
-def get_nasa_power_data(start_date, end_date, variables, lon, lat, output_fpath, overwrite):
-    """
-    Fetches weather data from the NASA POWER API for a given latitude and longitude between 
-    start_date and end_date if not already present in the output_dir.
-    """
-
-    if Path(output_fpath).exists and not overwrite:
-        logger.info("Weather data already exists locally. Skipping download for: \n%s", output_fpath)
-        return pd.read_csv(output_fpath)
-    
-    return fetch_nasa_power_data(start_date, end_date, variables, lon, lat)
-
-
-def download_file_ftp(file_name, output_fpath, ftp_connection):
-    """
-    Downloads a file form the cwd of a ftp connection
-    """
-    with open(output_fpath, 'wb') as local_file:
-        ftp_connection.retrbinary(f"RETR {file_name}", local_file.write)
-
-
-def fetch_chirps_daterange(start_date, end_date, output_dir):
-    chirps_basedir = '/pub/org/chg/products/CHIRPS-2.0/global_daily/cogs/p05'
-    ftp_connection = ftplib.FTP('ftp.chc.ucsb.edu')
-    ftp_connection.login('anonymous', 'your_email_address')
-    ftp_connection.cwd(chirps_basedir)
-
-    cur_ftp_dir_year = None
-    for date in pd.date_range(start_date, end_date):
-
-        year = date.year
-        if cur_ftp_dir_year != year:
-            ftp_connection.cwd(op.join(chirps_basedir, str(year)))
-            cur_ftp_dir_year = year
-
-        chirps_file_name = f'chirps-v2.0.{date.strftime("%Y.%m.%d")}.cog'
-        output_fpath = op.join(output_dir, chirps_file_name)
-        if not op.exists(output_fpath):
-            logger.info("Chirps precipitation data not existing locally for date {date}. Fetching and storing to: \n%s", output_fpath)
-            download_file_ftp(chirps_file_name, output_fpath, ftp_connection)
-
-    logger.info("Chirps data fetched successfully.")
-    ftp_connection.quit()
-
-
-def validate_chirps_aggregation_inp(aggregation_method, lon, lat, geometry_path):
-    """Validate the inputs based on the chosen aggregation method."""
-    if aggregation_method == 'centroid' and (lon is None or lat is None):
-        raise ValueError("Longitude and latitude must be provided for 'centroid' aggregation method.")
-
-    if aggregation_method == 'mean' and not geometry_path:
-        raise ValueError("A valid shapefile path must be provided for 'mean' aggregation method.")
-
-
-def get_dates_range(start_date, end_date):
-    """Generate a range of dates between the start and end dates."""
-    return pd.date_range(start_date, end_date)
-
-
-def read_chirps_file(chirps_dir, date):
-    """Generate the file path for a given date and read the CHIRPS data file."""
-    chirps_file_path = op.join(chirps_dir, f'chirps-v2.0.{date.strftime("%Y.%m.%d")}.cog')
-    return rasterio.open(chirps_file_path)
-
-
-def process_centroid_data(chirps_dir, dates, lon, lat):
-    """Process CHIRPS data using the centroid aggregation method."""
-    results = np.full(len(dates), np.nan)
-
-    for idx, date in enumerate(dates):
-        with read_chirps_file(chirps_dir, date) as src:
-            row, col = rowcol(src.transform, lon, lat)
-            try:
-                value = src.read(1)[row, col]
-            except IndexError:
-                raise Exception(f"Coordinates out of bounds for date {date}.")
-                # Handle cases where the coordinates are out of bounds by possibly falling back on nasa power
-            results[idx] = value
-
-    return results
-
-
-def process_mean_data(chirps_dir, dates, geometry):
-    """Process CHIRPS data using the mean aggregation method."""
-    results = np.full(len(dates), np.nan)
-
-    for idx, date in enumerate(dates):
-        with read_chirps_file(chirps_dir, date) as src:
-            chirps_data, _ = mask(src, geometry.geometry, crop=True, nodata=src.nodata)
-            chirps_mean = np.nanmean(chirps_data)
-            results[idx] = chirps_mean
-
-    return results
-
-
-def construct_chirps_data(start_date, end_date, aggregation_method, geometry_path=None, lon=None, lat=None, chirps_dir=None):
-    """
-    Constructs a DataFrame of CHIRPS precipitation data for the given date range and aggregation method.
-    
-    Parameters:
-        start_date (str): Start date in 'YYYY-MM-DD' format.
-        end_date (str): End date in 'YYYY-MM-DD' format.
-        aggregation_method (str): Aggregation method ('centroid' or 'mean').
-        geometry_path (str, optional): Path to a shapefile for the 'mean' aggregation method.
-        lon (float, optional): Longitude for the 'centroid' aggregation method.
-        lat (float, optional): Latitude for the 'centroid' aggregation method.
-        chirps_dir (str): Directory containing CHIRPS .cog files.
-
-    Returns:
-        pd.DataFrame: DataFrame with CHIRPS precipitation data.
-    """
-    validate_chirps_aggregation_inp(aggregation_method, lon, lat, geometry_path)
-
-    dates = get_dates_range(start_date, end_date)
-
-    if aggregation_method == 'centroid':
-        results = process_centroid_data(chirps_dir, dates, lon, lat)
-    elif aggregation_method == 'mean':
-        geometry = gpd.read_file(geometry_path)
-
-        # Chirps CRS is EPSG:4326
-        if geometry.crs != rasterio.crs.CRS.from_epsg(4326):
-            geometry = geometry.to_crs(rasterio.crs.CRS.from_epsg(4326))
-
-        results = process_mean_data(chirps_dir, dates, geometry)
-    else:
-        raise ValueError("Invalid aggregation method. Choose 'centroid' or 'mean'.")
-
-    return results
-
-
-def get_chirps_precipitation(start_date, end_date, aggregation_method, geometry_path, lon, lat, chirps_dir):
-    """
-    Fetches precipitation data from the CHIRPS API between start_date and end_date if not already present in the output_dir.
-    """
-
-    # TODO Fallback to NASA POWER if CHIRPS data is not available fr certain regions (-50 to 50 lat)
-    # TODO Parallelize this
-    # TODO Discuss if we want to decouple the chirps data fetching from the pipeline, e.g by running cron-jobs.
-    # TODO add better logging   
-    # TODO validate mean and centroid values. Currently large discrepancies to nasa power. Check scale
-
-    # Download CHIRPS data for the given data range
-    fetch_chirps_daterange(start_date, end_date, chirps_dir)
-    
-    # Process the CHIRPS data by the given spatial aggregation method
-    chirps_data = construct_chirps_data(start_date, end_date, aggregation_method, geometry_path, lon, lat, chirps_dir)
-
-    return chirps_data
-
-
-def write_met_data_to_csv(df, output_fpath):
-    """
-    Write the meteorological data to a CSV file.
-    """
-    df.to_csv(output_fpath)
+    # Writing the cleaned DataFrame to the CSV file
+    df_cleaned.to_csv(output_fpath)
 
     logger.info("Data successfully written to %s", output_fpath)
-    return output_fpath
 
 
 @click.command()
@@ -279,30 +118,16 @@ def write_met_data_to_csv(df, output_fpath):
 @click.option('--variables', type=click.Choice(VALID_CLIMATE_VARIABLES, case_sensitive=False), multiple=True, default=DEFAULT_CLIMATE_VARIABLES, show_default=True, help="Meteorological variables to fetch.")
 @click.option('--lon', type=float, required=True, help="Longitude of the location.")
 @click.option('--lat', type=float, required=True, help="Latitude of the location.")
-@click.option('--precipitation_source', type=click.Choice(['chirps', 'nasa_power'], case_sensitive=False), default='nasa_power', show_default=True, help="Source of precipitation data.")
-@click.option('--precipitation_aggregation_method', type=click.Choice(['centroid', 'mean'], case_sensitive=False), default='centroid', show_default=True, help="Method to spatially aggregate precipitation data.")
-@click.option('--geometry_path', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True), default=None, help="Path to the shapefile for the mean aggregation method.")
-@click.option('--chirps_dir', type=click.Path(file_okay=False, dir_okay=True, writable=True), default=None, help="Directory where the CHIRPS data is saved / will be saved.")
 @click.option('--output_dir', type=click.Path(file_okay=False, dir_okay=True, writable=True), required=True, help="Directory where the .csv file will be saved.")
 @click.option('--overwrite', is_flag=True, help="Enable file overwriting if weather data already exists.")
 @click.option('--verbose', is_flag=True, help="Enable verbose logging.")
-def cli(start_date, end_date, variables, lon, lat, precipitation_source, precipitation_aggregation_method, geometry_path, chirps_dir, output_dir, overwrite, verbose):
+def cli(start_date, end_date, variables, lon, lat, output_dir, overwrite, verbose):
     """Wrapper to fetch_met_data"""
     if verbose:
         logger.setLevel('INFO')
 
-    region = Path(output_dir).stem
-    output_fpath = op.join(output_dir, f'{region}_nasapower.csv')
+    fetch_nasa_power_data(start_date, end_date, variables, lon, lat, output_dir, overwrite)
 
-    df = get_nasa_power_data(start_date, end_date, variables, lon, lat, output_dir, overwrite)
-
-    if precipitation_source == 'chirps':
-        chirps_data = get_chirps_precipitation(start_date, end_date, precipitation_aggregation_method, geometry_path, lon, lat, chirps_dir)
-        if len(chirps_data) != len(df):
-            raise ValueError("NasaPower and Chirps data do not have the same length.")
-        df['PRECTOTCORR'] = chirps_data
-
-    write_met_data_to_csv(df, output_fpath)
 
 if __name__ == '__main__':
     cli()

--- a/vercye_ops/apsim/fetch_met_data.py
+++ b/vercye_ops/apsim/fetch_met_data.py
@@ -1,11 +1,19 @@
 """CLI tools for fetching/formatting meteorological data"""
 
+import os
 import os.path as op
 from pathlib import Path
 
 import click
-import requests
+import ftplib
+import geopandas as gpd
+import numpy as np
 import pandas as pd
+import rasterio
+from rasterio.mask import mask
+from rasterio.transform import rowcol
+import requests
+
 
 from vercye_ops.utils.init_logger import get_logger
 
@@ -65,16 +73,11 @@ def error_checking_function(df):
     return df
 
 
-def fetch_nasa_power_data(start_date, end_date, variables, lon, lat, output_dir, overwrite):
+def fetch_nasa_power_data(start_date, end_date, variables, lon, lat):
     """
     Fetches weather data from the NASA POWER API for a given latitude and longitude between start_date and end_date,
-    for the desired variables, and writes it to a CSV after processing.
+    for the desired variables.
     """
-    region = Path(output_dir).stem
-    output_fpath = op.join(output_dir, f'{region}_nasapower.csv')
-    if Path(output_fpath).exists and not overwrite:
-        logger.info("Weather data already exists locally. Skipping: \n%s", output_fpath)
-        return
 
     logger.info("Fetching data from NASA POWER for %s to %s...", start_date.date(), end_date.date())
 
@@ -106,10 +109,168 @@ def fetch_nasa_power_data(start_date, end_date, variables, lon, lat, output_dir,
     # TODO: Flesh out required checks
     df_cleaned = error_checking_function(df)
 
-    # Writing the cleaned DataFrame to the CSV file
-    df_cleaned.to_csv(output_fpath)
+    return df_cleaned
+
+
+def get_nasa_power_data(start_date, end_date, variables, lon, lat, output_fpath, overwrite):
+    """
+    Fetches weather data from the NASA POWER API for a given latitude and longitude between 
+    start_date and end_date if not already present in the output_dir.
+    """
+
+    if Path(output_fpath).exists and not overwrite:
+        logger.info("Weather data already exists locally. Skipping download for: \n%s", output_fpath)
+        return pd.read_csv(output_fpath)
+    
+    return fetch_nasa_power_data(start_date, end_date, variables, lon, lat)
+
+
+def download_file_ftp(file_name, output_fpath, ftp_connection):
+    """
+    Downloads a file form the cwd of a ftp connection
+    """
+    with open(output_fpath, 'wb') as local_file:
+        ftp_connection.retrbinary(f"RETR {file_name}", local_file.write)
+
+
+def fetch_chirps_daterange(start_date, end_date, output_dir):
+    chirps_basedir = '/pub/org/chg/products/CHIRPS-2.0/global_daily/cogs/p05'
+    ftp_connection = ftplib.FTP('ftp.chc.ucsb.edu')
+    ftp_connection.login('anonymous', 'your_email_address')
+    ftp_connection.cwd(chirps_basedir)
+
+    cur_ftp_dir_year = None
+    for date in pd.date_range(start_date, end_date):
+
+        year = date.year
+        if cur_ftp_dir_year != year:
+            ftp_connection.cwd(op.join(chirps_basedir, str(year)))
+            cur_ftp_dir_year = year
+
+        chirps_file_name = f'chirps-v2.0.{date.strftime("%Y.%m.%d")}.cog'
+        output_fpath = op.join(output_dir, chirps_file_name)
+        if not op.exists(output_fpath):
+            logger.info("Chirps precipitation data not existing locally for date {date}. Fetching and storing to: \n%s", output_fpath)
+            download_file_ftp(chirps_file_name, output_fpath, ftp_connection)
+
+    logger.info("Chirps data fetched successfully.")
+    ftp_connection.quit()
+
+
+def validate_chirps_aggregation_inp(aggregation_method, lon, lat, geometry_path):
+    """Validate the inputs based on the chosen aggregation method."""
+    if aggregation_method == 'centroid' and (lon is None or lat is None):
+        raise ValueError("Longitude and latitude must be provided for 'centroid' aggregation method.")
+
+    if aggregation_method == 'mean' and not geometry_path:
+        raise ValueError("A valid shapefile path must be provided for 'mean' aggregation method.")
+
+
+def get_dates_range(start_date, end_date):
+    """Generate a range of dates between the start and end dates."""
+    return pd.date_range(start_date, end_date)
+
+
+def read_chirps_file(chirps_dir, date):
+    """Generate the file path for a given date and read the CHIRPS data file."""
+    chirps_file_path = op.join(chirps_dir, f'chirps-v2.0.{date.strftime("%Y.%m.%d")}.cog')
+    return rasterio.open(chirps_file_path)
+
+
+def process_centroid_data(chirps_dir, dates, lon, lat):
+    """Process CHIRPS data using the centroid aggregation method."""
+    results = np.full(len(dates), np.nan)
+
+    for idx, date in enumerate(dates):
+        with read_chirps_file(chirps_dir, date) as src:
+            row, col = rowcol(src.transform, lon, lat)
+            try:
+                value = src.read(1)[row, col]
+            except IndexError:
+                raise Exception(f"Coordinates out of bounds for date {date}.")
+                # Handle cases where the coordinates are out of bounds by possibly falling back on nasa power
+            results[idx] = value
+
+    return results
+
+
+def process_mean_data(chirps_dir, dates, geometry):
+    """Process CHIRPS data using the mean aggregation method."""
+    results = np.full(len(dates), np.nan)
+
+    for idx, date in enumerate(dates):
+        with read_chirps_file(chirps_dir, date) as src:
+            chirps_data, _ = mask(src, geometry.geometry, crop=True, nodata=src.nodata)
+            chirps_mean = np.nanmean(chirps_data)
+            results[idx] = chirps_mean
+
+    return results
+
+
+def construct_chirps_data(start_date, end_date, aggregation_method, geometry_path=None, lon=None, lat=None, chirps_dir=None):
+    """
+    Constructs a DataFrame of CHIRPS precipitation data for the given date range and aggregation method.
+    
+    Parameters:
+        start_date (str): Start date in 'YYYY-MM-DD' format.
+        end_date (str): End date in 'YYYY-MM-DD' format.
+        aggregation_method (str): Aggregation method ('centroid' or 'mean').
+        geometry_path (str, optional): Path to a shapefile for the 'mean' aggregation method.
+        lon (float, optional): Longitude for the 'centroid' aggregation method.
+        lat (float, optional): Latitude for the 'centroid' aggregation method.
+        chirps_dir (str): Directory containing CHIRPS .cog files.
+
+    Returns:
+        pd.DataFrame: DataFrame with CHIRPS precipitation data.
+    """
+    validate_chirps_aggregation_inp(aggregation_method, lon, lat, geometry_path)
+
+    dates = get_dates_range(start_date, end_date)
+
+    if aggregation_method == 'centroid':
+        results = process_centroid_data(chirps_dir, dates, lon, lat)
+    elif aggregation_method == 'mean':
+        geometry = gpd.read_file(geometry_path)
+
+        # Chirps CRS is EPSG:4326
+        if geometry.crs != rasterio.crs.CRS.from_epsg(4326):
+            geometry = geometry.to_crs(rasterio.crs.CRS.from_epsg(4326))
+
+        results = process_mean_data(chirps_dir, dates, geometry)
+    else:
+        raise ValueError("Invalid aggregation method. Choose 'centroid' or 'mean'.")
+
+    return results
+
+
+def get_chirps_precipitation(start_date, end_date, aggregation_method, geometry_path, lon, lat, chirps_dir):
+    """
+    Fetches precipitation data from the CHIRPS API between start_date and end_date if not already present in the output_dir.
+    """
+
+    # TODO Fallback to NASA POWER if CHIRPS data is not available fr certain regions (-50 to 50 lat)
+    # TODO Parallelize this
+    # TODO Discuss if we want to decouple the chirps data fetching from the pipeline, e.g by running cron-jobs.
+    # TODO add better logging   
+    # TODO validate mean and centroid values. Currently large discrepancies to nasa power. Check scale
+
+    # Download CHIRPS data for the given data range
+    fetch_chirps_daterange(start_date, end_date, chirps_dir)
+    
+    # Process the CHIRPS data by the given spatial aggregation method
+    chirps_data = construct_chirps_data(start_date, end_date, aggregation_method, geometry_path, lon, lat, chirps_dir)
+
+    return chirps_data
+
+
+def write_met_data_to_csv(df, output_fpath):
+    """
+    Write the meteorological data to a CSV file.
+    """
+    df.to_csv(output_fpath)
 
     logger.info("Data successfully written to %s", output_fpath)
+    return output_fpath
 
 
 @click.command()
@@ -118,16 +279,30 @@ def fetch_nasa_power_data(start_date, end_date, variables, lon, lat, output_dir,
 @click.option('--variables', type=click.Choice(VALID_CLIMATE_VARIABLES, case_sensitive=False), multiple=True, default=DEFAULT_CLIMATE_VARIABLES, show_default=True, help="Meteorological variables to fetch.")
 @click.option('--lon', type=float, required=True, help="Longitude of the location.")
 @click.option('--lat', type=float, required=True, help="Latitude of the location.")
+@click.option('--precipitation_source', type=click.Choice(['chirps', 'nasa_power'], case_sensitive=False), default='nasa_power', show_default=True, help="Source of precipitation data.")
+@click.option('--precipitation_aggregation_method', type=click.Choice(['centroid', 'mean'], case_sensitive=False), default='centroid', show_default=True, help="Method to spatially aggregate precipitation data.")
+@click.option('--geometry_path', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True), default=None, help="Path to the shapefile for the mean aggregation method.")
+@click.option('--chirps_dir', type=click.Path(file_okay=False, dir_okay=True, writable=True), default=None, help="Directory where the CHIRPS data is saved / will be saved.")
 @click.option('--output_dir', type=click.Path(file_okay=False, dir_okay=True, writable=True), required=True, help="Directory where the .csv file will be saved.")
 @click.option('--overwrite', is_flag=True, help="Enable file overwriting if weather data already exists.")
 @click.option('--verbose', is_flag=True, help="Enable verbose logging.")
-def cli(start_date, end_date, variables, lon, lat, output_dir, overwrite, verbose):
+def cli(start_date, end_date, variables, lon, lat, precipitation_source, precipitation_aggregation_method, geometry_path, chirps_dir, output_dir, overwrite, verbose):
     """Wrapper to fetch_met_data"""
     if verbose:
         logger.setLevel('INFO')
 
-    fetch_nasa_power_data(start_date, end_date, variables, lon, lat, output_dir, overwrite)
+    region = Path(output_dir).stem
+    output_fpath = op.join(output_dir, f'{region}_nasapower.csv')
 
+    df = get_nasa_power_data(start_date, end_date, variables, lon, lat, output_dir, overwrite)
+
+    if precipitation_source == 'chirps':
+        chirps_data = get_chirps_precipitation(start_date, end_date, precipitation_aggregation_method, geometry_path, lon, lat, chirps_dir)
+        if len(chirps_data) != len(df):
+            raise ValueError("NasaPower and Chirps data do not have the same length.")
+        df['PRECTOTCORR'] = chirps_data
+
+    write_met_data_to_csv(df, output_fpath)
 
 if __name__ == '__main__':
     cli()

--- a/vercye_ops/apsim/prepare_shapefile.py
+++ b/vercye_ops/apsim/prepare_shapefile.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+import click
+import geopandas as gpd
+
+from vercye_ops.utils.init_logger import get_logger
+
+logger = get_logger()
+
+
+def standardize_shapefile(shp_fpath, output_dir):
+    """
+    Read a shapefile using Geopandas, standardize the column names of the administrative divisions, and save the file to a new location.
+
+    Parameters:
+    -----------
+    shp_fpath : str
+        The path to the .shp file.
+    output_dir : str
+        The dir where the new shapefile will be saved.
+
+    Returns:
+    --------
+    None
+    """
+
+    shp_fpath = Path(shp_fpath)
+
+    if output_dir is None:
+        output_dir = Path(shp_fpath.parent, shp_fpath.stem + '_standardized')
+
+        if output_dir.exists():
+            raise Exception(f'There already exists a standardized shapefile under the default directory ({output_dir}). Please use --output_dir to specify a different location.')
+
+    output_fpath = Path(output_dir, shp_fpath.stem + '_standardized' + shp_fpath.suffix)
+    
+    # Read shapefile
+    gdf = gpd.read_file(shp_fpath)
+
+    logger.info('The administrative division column specifies the administrative level of the region, e.g this could typically be a state or a district etc.')
+
+    # Validate that only a single administrative division name column is present
+    if 'NAME_1' in gdf.columns and not 'NAME_2' in gdf.columns and not 'NAME_3' in gdf.columns:
+        logger.info('The shapefile is already standardized as contains a single administrative division name column "Name_1".')
+        
+        logger.info('Would you like to set a different column as the administrative division level? (y/n)')
+        user_input = input()
+
+        if user_input.lower() == 'n':
+            return
+    
+    if sum(col in gdf.columns for col in ['NAME_0', 'NAME_1', 'NAME_2', 'NAME_3']) > 1:
+        logger.info('The shapefile contains multiple known administrative division name columns (e.g "Name_0", "Name_1", "Name_2", "Name_3"). Please select the administrative level for which you want to do the analysis')
+
+    # Print examples for values in each column
+    logger.info('Columns in the shapefile:')
+    for col in gdf.columns:
+        if col == 'geometry':
+            continue
+        entries_to_log = min(5, len(gdf[col].unique()))
+        logger.info(f'Column name: "{col}". Examples: {gdf[col].unique()[:entries_to_log]}')
+
+    logger.info('Please type the name of the column that contains the name of the administrative level for which you want to do the analysis.')
+    
+    admin_column_name = input()
+
+    if admin_column_name not in gdf.columns:
+        raise ValueError('The column name provided is not valid. Please provide a valid column name from the list above.')
+        
+    # Drop Name_2, Name_3 columns if they exist
+    gdf.drop(columns=['NAME_2', 'NAME_3'], errors='ignore', inplace=True)
+
+    # Rename the column to NAME_1
+    gdf.rename(columns={admin_column_name: 'NAME_1'}, inplace=True)
+
+    # Save as modified shapefile
+    output_dir.mkdir(exist_ok=True)
+    gdf.to_file(output_fpath)
+    
+    logger.info('Processing Complete. Please manually ensure the resulting shapefile administrative division column names are as expected.')
+    logger.info(f'Saving shapefile to {output_fpath}. Please use this file as input for the following steps.')
+
+
+@click.command()
+@click.option('--shp_fpath', type=click.Path(exists=True), help='Path to the .shp file.')
+@click.option('--output_dir', type=click.Path(file_okay=False), default=None, help='Optional: Dir where the standardized output file for the Vercye pipeline is saved.')
+def cli(shp_fpath, output_dir):
+    
+    logger.setLevel('INFO')
+    standardize_shapefile(shp_fpath, output_dir)
+    
+    
+if __name__ == '__main__':
+    cli()

--- a/vercye_ops/lai/1_1_gee_export_S2.py
+++ b/vercye_ops/lai/1_1_gee_export_S2.py
@@ -59,20 +59,20 @@ def main(project, library=None, region=None, shpfile=None, start_date="2021-09-0
     all_start = time.time()
 
     if shpfile is None and region is None:
-        raise ValueError("Either a shapefile or oblast should be specified.")
+        raise ValueError("Either a shapefile or administrative division (region) should be specified.")
     elif shpfile is not None and region is not None:
         raise ValueError("Only one of shapefile or crop mask should be specified.")
 
     # Get geometry 
     if region is not None:
         # Look for geojson in the library
-        oblast_geojsons = glob(f"{library}/{region}.geojson")
+        region_geojsons = glob(f"{library}/{region}.geojson")
 
-        if len(oblast_geojsons) == 0:
+        if len(region_geojsons) == 0:
             raise FileNotFoundError(f"{library}/{region}.geojson not found.")
         
-        shp = json_to_fc(oblast_geojsons[0])
-        print(f"Loaded geometry from {oblast_geojsons[0]}")
+        shp = json_to_fc(region_geojsons[0])
+        print(f"Loaded geometry from {region_geojsons[0]}")
     elif shpfile is not None:
         # Override with shp file
         shp = shp_to_fc(shpfile)

--- a/vercye_ops/lai/README.md
+++ b/vercye_ops/lai/README.md
@@ -454,7 +454,8 @@ $ python 0_reproj_mask.py \
 
 ### 0_build_library.py
 
-This script takes a single `shp` file of region-defining polygons and exports each one to a `geojson` for future reference. It is currently Ukraine-specific.
+This script takes a single `shp` file of region-defining polygons and exports each one to a `geojson` for future reference.
+The shapefile attribute data must contain a column for the administrative division name (region) called "admin_name". The file is only allowed to contain entries that specify geometries for this administrative level. You can also use the `prepare_shapefile.py` script in the `apsim` directory to preprocess your shapefile to follow these conventions. If using the script, ensure you use the newly created file from the script in the following steps. We recommend to additionally manually ensure that your shapefile does not mix entries from different administrative levels.
 
 ```
 $ python 0_build_library.py --help
@@ -463,9 +464,6 @@ Usage: 0_build_library.py [OPTIONS] SHP_FPATH
   Wrapper around geojson generation func
 
 Options:
-  --admin_level [oblast|raion]  Level of administration to process. `oblast`
-                                corresponds to Level 1, `raion` corresponds to
-                                Level 2
   --output_head_dir DIRECTORY   Head directory where the region output dirs
                                 will be created.
   --verbose                     Print verbose output.

--- a/vercye_ops/version.py
+++ b/vercye_ops/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.1.dev13+g3a2eb81.d20241218'
+__version__ = '0.1.dev15+gba8f31d.d20241226'


### PR DESCRIPTION
### Summary

**Closes #4**

This PR refactors the process of extracting ROI GeoJSONs from shapefiles, removing the current Ukraine-specific constraints and making the pipeline more generalizable.

---

### Current Behavior

The existing script, `convert_shapefile_to_geojson.py`, relies on CLI parameters to specify administrative division levels (e.g., Oblast or Raion). It assumes the shapefile has attribute columns named `Name_1` or `Name_2` for these levels. This approach:
- Is Ukraine-specific.
- Is incompatible with shapefiles that do not adhere to this naming convention.

---

### Changes Introduced

1. **Column Standardization**:
   - The script now requires a standardized column named `admin_name` in the shapefile's attribute data. 
   - This enforces consistency and removes the dependency on region-specific column names like `Name_1` or `Name_2`.
   - For shapefiles lacking this column, the pipeline will raise an error. As this is not a standard column name, this will enforce users to preprocess their data meaningfully before execution.

2. **Preprocessing Script**:
   - A new preprocessing script is provided to help users adapt their shapefiles to the required format.
   - Users can:
     - Select a column that holds the relevant administrative level name for their analysis. These values are written to the new `admin_name` column.
   - The script helps ensures that only geometries of a single administrative level are present in the shapefile by:
     - Making the user input all admin level columns
     - Checking for null values in administrative level columns.
     - Identifying rows with geometries for the desired administrative level only.

---

### Benefits
- Makes the pipeline region-agnostic and adaptable to diverse shapefiles.
- Ensures data consistency via enforced preprocessing.
- Provides a structured approach for handling non-standard shapefiles.

---
