### PR TITLE
Feature/remove apsim dbfiles

### DIFF
--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -109,7 +109,6 @@ rule update_apsimx_template:
 
 
 # Rule to run the APSIM executable (via local executable) on .apsimx files
-'''
 rule execute_simulations:
     input:
         op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.apsimx'),
@@ -135,9 +134,9 @@ rule execute_simulations:
         --cpu-count {params.n_jobs} \
         --verbose > {log}
         """
-'''
 
 # Rule to run the APSIM executable (via docker) on .apsimx files
+'''
 rule execute_simulations:
     input:
         op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.apsimx'),
@@ -165,6 +164,7 @@ rule execute_simulations:
         {input} \
         --verbose > {log}
         """
+'''
 
 #######################################
 # S2/LAI portion of Snakemake pipeline

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -119,7 +119,11 @@ rule execute_simulations:
     log:
         'logs_execute_simulation/{year}_{timepoint}_{region}.log',
     output:
-        db_file = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db')
+        db_file = (
+            op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db')
+            if config['keep_apsim_db_files']
+            else temp(op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db'))
+        )
     retries: 2
     benchmark:
         "benchmarks/execute_simulations_{year}_{timepoint}_{region}.txt"
@@ -143,7 +147,11 @@ rule execute_simulations:
     log:
         'logs_execute_simulation/{year}_{timepoint}_{region}.log',
     output:
-        db_file = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db'),
+        db_file = (
+            op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db')
+            if config['keep_apsim_db_files']
+            else temp(op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db'))
+        )
     retries: 5  # Docker image has habit of failing sometimes 
     benchmark:
         "benchmarks/execute_simulations_{year}_{timepoint}_{region}.txt"

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -109,6 +109,7 @@ rule update_apsimx_template:
 
 
 # Rule to run the APSIM executable (via local executable) on .apsimx files
+'''
 rule execute_simulations:
     input:
         op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.apsimx'),
@@ -134,8 +135,8 @@ rule execute_simulations:
         --cpu-count {params.n_jobs} \
         --verbose > {log}
         """
-
 '''
+
 # Rule to run the APSIM executable (via docker) on .apsimx files
 rule execute_simulations:
     input:
@@ -159,11 +160,11 @@ rule execute_simulations:
         """
         docker run -i --rm --platform={params.docker_platform} \
         -v "{params.head_dir}:{params.head_dir}" \
+        -u $(id -u ${{USER}}):$(id -g ${{USER}}) \
         {params.docker_image} \
         {input} \
         --verbose > {log}
         """
-'''
 
 #######################################
 # S2/LAI portion of Snakemake pipeline

--- a/vercye_ops/snakemake/config_local.yaml
+++ b/vercye_ops/snakemake/config_local.yaml
@@ -107,6 +107,10 @@ apsim_execution:
     platform: 'linux/amd64'
   local_exe: '~/Builds/APSIMInitiative/ApsimX/bin/Release/net6.0/Models'
 
+# For each simulation APSIM generates a .db file. These take up a lot of space on disk. If you want to remove these files,
+# after the pipeline finishes, set this to False.
+keep_apsim_db_files: True
+
 ########################################
 # LAI parameters
 lai_params:

--- a/vercye_ops/snakemake/config_umd.yaml
+++ b/vercye_ops/snakemake/config_umd.yaml
@@ -109,6 +109,10 @@ apsim_execution:
     executable_fpath: '/gpfs/data1/cmongp2/wronk/Builds/ApsimX/bin/Release/net6.0/Models'
     n_jobs: -1  # Number of threads to spawn. -1 is default in APSIM. Only change if you wish to control APSIM parallelization
 
+# For each simulation APSIM generates a .db file. These take up a lot of space on disk. If you want to remove these files,
+# after the pipeline finishes, set this to False.
+keep_apsim_db_files: True
+
 ########################################
 # LAI parameters
 lai_params:


### PR DESCRIPTION
### Summary

**Closes #1**

This PR allows to set a config param to automatically delete APSIM DB files after the pipeline execution finishes.

---

### Current Behavior

All DB Files of APSIM simulations are stored on disk. Each file can be as large as 250MB thus leading to large experiment folders. Often this data is not further required.

---

### Changes Introduced
- Allow setting a parameter in the Snakemake config, specifying whether to keep or remove APSIM DB files after pipeline finishes.
- Based on the parameter conditionally setting the APSIM DB file as a Snakemake tempfile. File cleanup is handled by Snakemake.

### Changes Introduced not related to branch
- Added a folder for custom local snakemake configs that is ignored by git.
- Running APSIM docker image as the current user. This avoids running with root privileges by the often default docker config. Prevents artifacts that are owned by root. **Can be discussed if this should be kept.**
