### PR TITLE
Feature/apsim docker conditionally

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,8 +1,7 @@
 name: Bug Report
 description: Report a bug in the project
 title: "[BUG] "
-labels: bugsudo apt-get install -y libgdal-dev gdal-bin python3-gdal
-assignees: ''
+labels: bug
 
 body:
   - type: markdown
@@ -32,7 +31,6 @@ body:
     attributes:
       label: Screenshots or logs
       description: Provide screenshots or log output to help us diagnose the issue.
-  - type: dropdown
   - type: textarea
     attributes:
       label: Additional context

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -2,7 +2,6 @@ name: Feature Request
 description: Propose a new feature or enhancement
 title: "[FEATURE] "
 labels: enhancement
-assignees: ''
 
 body:
   - type: markdown

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,8 @@ cython_debug/
 .snakemake
 vercye_ops/snakemake/logs*
 vercye_ops/snakemake/benchmarks*
+vercye_ops/snakemake/custom_configs/*
+!vercye_ops/snakemake/custom_configs/.gitkeep
 
 # Packaged release
 *.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ earthengine-api
 ee
 gdal
 geopandas
+joblib
 kaleido  # For static image plots in plotly
 numpy
 pandas

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -116,14 +116,14 @@ rule execute_simulations:
     params:
         head_dir = config['sim_study_head_dir'],
         use_docker =  config['apsim_execution']['use_docker'],
-        execution_command = build_apsim_execution_command(
+        execution_command = lambda wildcards, input: build_apsim_execution_command(
             config['sim_study_head_dir'],
             config['apsim_execution']['use_docker'],
             config['apsim_execution']['docker']['image'],
             config['apsim_execution']['docker']['platform'],
             config['apsim_execution']['local']['executable_fpath'],
             config['apsim_execution']['local']['n_jobs'],
-            op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.apsimx'))
+            input)
     log:
         'logs_execute_simulation/{year}_{timepoint}_{region}.log',
     output:

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -3,6 +3,8 @@
 
 import os.path as op
 
+from snakefile_helpers import build_apsim_execution_command
+
 rule all:
     input:
         #sim_match_output_fpath = expand(op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}_sim_matches.csv'), year=config['years'], region=config['regions'], timepoint=config['timepoints']),
@@ -107,55 +109,32 @@ rule update_apsimx_template:
         --verbose > {log}
         """
 
-
 # Rule to run the APSIM executable (via local executable) on .apsimx files
 rule execute_simulations:
     input:
         op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.apsimx'),
     params:
         head_dir = config['sim_study_head_dir'],
-        executable_fpath = config['apsim_execution']['local']['executable_fpath'],
-        n_jobs = config['apsim_execution']['local']['n_jobs']
+        use_docker =  config['apsim_execution']['use_docker'],
+        execution_command = build_apsim_execution_command(
+            config['sim_study_head_dir'],
+            config['apsim_execution']['use_docker'],
+            config['apsim_execution']['docker']['image'],
+            config['apsim_execution']['docker']['platform'],
+            config['apsim_execution']['local']['executable_fpath'],
+            config['apsim_execution']['local']['n_jobs'],
+            op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.apsimx'))
     log:
         'logs_execute_simulation/{year}_{timepoint}_{region}.log',
     output:
         db_file = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db')
-    retries: 2
+    retries: 2 if not config['apsim_execution']['use_docker'] else 5  # Docker image has habit of failing sometimes
     benchmark:
         "benchmarks/execute_simulations_{year}_{timepoint}_{region}.txt"
     shell:
         """
-        {params.executable_fpath} \
-        {input} \
-        --cpu-count {params.n_jobs} \
-        --verbose > {log}
+        {params.execution_command} --verbose > {log}
         """
-
-'''
-# Rule to run the APSIM executable (via docker) on .apsimx files
-rule execute_simulations:
-    input:
-        op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.apsimx'),
-    params:
-        head_dir = config['sim_study_head_dir'],
-        docker_image = config['apsim_execution']['docker']['image'],
-        docker_platform = config['apsim_execution']['docker']['platform'],
-    log:
-        'logs_execute_simulation/{year}_{timepoint}_{region}.log',
-    output:
-        db_file = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db'),
-    retries: 5  # Docker image has habit of failing sometimes 
-    benchmark:
-        "benchmarks/execute_simulations_{year}_{timepoint}_{region}.txt"
-    shell:
-        """
-        docker run -i --rm --platform={params.docker_platform} \
-        -v "{params.head_dir}:{params.head_dir}" \
-        {params.docker_image} \
-        {input} \
-        --verbose > {log}
-        """
-'''
 
 #######################################
 # S2/LAI portion of Snakemake pipeline

--- a/vercye_ops/snakemake/config_local.yaml
+++ b/vercye_ops/snakemake/config_local.yaml
@@ -102,10 +102,13 @@ apsim_params:
 
 # If using Docker, make sure to pull the docker image before executing this snakemake pipeline
 apsim_execution:
+  use_docker: False
   docker:
     image: 'apsiminitiative/apsimng'
     platform: 'linux/amd64'
-  local_exe: '~/Builds/APSIMInitiative/ApsimX/bin/Release/net6.0/Models'
+  local: 
+    executable_fpath: '/gpfs/data1/cmongp2/wronk/Builds/ApsimX/bin/Release/net6.0/Models'
+    n_jobs: -1  # Number of threads to spawn. -1 is default in APSIM. Only change if you wish to control APSIM parallelization
 
 ########################################
 # LAI parameters

--- a/vercye_ops/snakemake/config_umd.yaml
+++ b/vercye_ops/snakemake/config_umd.yaml
@@ -102,6 +102,7 @@ apsim_params:
 
 # If using Docker, make sure to pull the docker image before executing this snakemake pipeline
 apsim_execution:
+  use_docker: False
   docker:
     image: 'apsiminitiative/apsimng'
     platform: 'linux/amd64'

--- a/vercye_ops/snakemake/snakefile_helpers.py
+++ b/vercye_ops/snakemake/snakefile_helpers.py
@@ -1,0 +1,17 @@
+def build_apsim_execution_command(head_dir, use_docker, docker_image, docker_platform, executable_fpath, n_jobs, input_file):
+    '''Builds the APSIM execution command depending on whether we are using APSIM in Docker or not'''
+
+    if use_docker:
+        return (
+            f'docker run -i --rm --platform={docker_platform} '
+            f'-v "{head_dir}:{head_dir}" '
+            f'-u $(id -u):$(id -g) '
+            f'{docker_image} '
+            f'{input_file} '
+        )
+    else:
+        return (
+            f'{executable_fpath} '
+            f'{input_file} '
+            f'--cpu-count {n_jobs} '
+        )


### PR DESCRIPTION
### Summary

This PR allows to set a config param specifying whether to run APSIM as a docker image or with a local executable.

---

### Current Behavior

The user has to un/-comment different rules in the Snakefile for executing APSIM simulations either with docker or with a local executable.

---

### Changes Introduced
- Allow setting a parameter in the Snakemake config, specifying whether to use docker for APSIM.
- Based on the parameter conditionally constructing the shell command to execute APSIM either in docker or with the executable.
