### PR TITLE
Feature/extended aggregated yield summaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,8 @@ cython_debug/
 .snakemake
 vercye_ops/snakemake/logs*
 vercye_ops/snakemake/benchmarks*
+vercye_ops/snakemake/custom_configs/*
+!vercye_ops/snakemake/custom_configs/.gitkeep
 
 # Packaged release
 *.tar.gz

--- a/vercye_ops/matching_sim_real/aggregate_yield_estimates.py
+++ b/vercye_ops/matching_sim_real/aggregate_yield_estimates.py
@@ -39,7 +39,7 @@ def aggregate_yields(yield_dir):
 
             if conv_factor_csv_path.exists():
                 conv_df = pd.read_csv(conv_factor_csv_path)
-                conv_df = conv_df[['max_rs_lai', 'max_rs_lai_date']]
+                conv_df = conv_df[['max_rs_lai', 'max_rs_lai_date', 'apsim_mean_yield_estimate', 'max_matched_sim_lai', 'max_matched_sim_lai_date', 'max_total_sim_lai', 'max_total_sim_lai_date']]
                 conv_df['region'] = region_name
             else:
                 conv_df = pd.DataFrame()  # Empty DataFrame as a fallback

--- a/vercye_ops/matching_sim_real/aggregate_yield_estimates.py
+++ b/vercye_ops/matching_sim_real/aggregate_yield_estimates.py
@@ -39,7 +39,18 @@ def aggregate_yields(yield_dir):
 
             if conv_factor_csv_path.exists():
                 conv_df = pd.read_csv(conv_factor_csv_path)
-                conv_df = conv_df[['max_rs_lai', 'max_rs_lai_date', 'apsim_mean_yield_estimate', 'max_matched_sim_lai', 'max_matched_sim_lai_date', 'max_total_sim_lai', 'max_total_sim_lai_date']]
+                conv_df = conv_df[['max_rs_lai', 
+                                   'max_rs_lai_date', 
+                                   'apsim_mean_yield_estimate', 
+                                   'max_matched_sim_lai', 
+                                   'max_matched_sim_lai_date', 
+                                   'max_total_sim_lai', 
+                                   'max_total_sim_lai_date',
+                                   'apsim_matched_std_yield_estimate',
+                                   'apsim_total_std_yield_estimate',
+                                   'apsim_matched_maxlai_std',
+                                   'apsim_total_maxlai_std',
+                                   ]]
                 conv_df['region'] = region_name
             else:
                 conv_df = pd.DataFrame()  # Empty DataFrame as a fallback

--- a/vercye_ops/matching_sim_real/aggregate_yield_estimates.py
+++ b/vercye_ops/matching_sim_real/aggregate_yield_estimates.py
@@ -27,18 +27,32 @@ def aggregate_yields(yield_dir):
     for region_dir in Path(yield_dir).iterdir():
         if region_dir.is_dir():
             region_name = region_dir.name
-            csv_path = region_dir / f"{region_name}_converted_map_yield_estimate.csv"
+            yield_estimate_csv_path = region_dir / f"{region_name}_converted_map_yield_estimate.csv"
+            conv_factor_csv_path = region_dir / f"{region_name}_conversion_factor.csv"
             
-            if csv_path.exists():
-                df = pd.read_csv(csv_path)
-                df['region'] = region_name
-                all_yields.append(df)
+            if yield_estimate_csv_path.exists():
+                yield_df = pd.read_csv(yield_estimate_csv_path)
+                yield_df['region'] = region_name
             else:
-                logger.warning(f"CSV file not found for region: {region_name}")
-    
-    if not all_yields:
-        logger.error("No yield estimate CSV files found in any region.")
-        return None
+                yield_df = pd.DataFrame()  # Empty DataFrame as a fallback
+                logger.warning(f"Converted map yield estimate CSV file not found for region: {region_name}")
+
+            if conv_factor_csv_path.exists():
+                conv_df = pd.read_csv(conv_factor_csv_path)
+                conv_df = conv_df[['max_rs_lai', 'max_rs_lai_date']]
+                conv_df['region'] = region_name
+            else:
+                conv_df = pd.DataFrame()  # Empty DataFrame as a fallback
+                logger.warning(f"Conversion factor CSV file not found for region: {region_name}")
+
+            # Merge the DataFrames
+            if not yield_df.empty or not conv_df.empty:
+                combined_df = pd.merge(yield_df, conv_df, on='region', how='outer')
+                all_yields.append(combined_df)
+                
+                if not all_yields:
+                    logger.error("No yield estimate CSV files found in any region.")
+                    return None
     
     aggregated_yields = pd.concat(all_yields, ignore_index=True)
     

--- a/vercye_ops/matching_sim_real/aggregate_yield_estimates.py
+++ b/vercye_ops/matching_sim_real/aggregate_yield_estimates.py
@@ -51,7 +51,19 @@ def aggregate_yields(yield_dir):
                                    'apsim_matched_maxlai_std',
                                    'apsim_total_maxlai_std',
                                    ]]
-                conv_df['region'] = region_name
+                
+                conv_df['max_rs_lai'] = conv_df['max_rs_lai'].round(2)
+                conv_df['apsim_mean_yield_estimate'] = conv_df['apsim_mean_yield_estimate'].astype(int)
+                conv_df['max_matched_sim_lai'] = conv_df['max_matched_sim_lai'].round(2)
+                conv_df['max_total_sim_lai'] = conv_df['max_total_sim_lai'].round(2)
+                conv_df['apsim_matched_maxlai_std'] = conv_df['apsim_matched_maxlai_std'].round(2)
+                conv_df['apsim_total_maxlai_std'] = conv_df['apsim_total_maxlai_std'].round(2)
+                conv_df['apsim_matched_std_yield_estimate'] = conv_df['apsim_matched_std_yield_estimate'].astype(int)
+                conv_df['apsim_total_std_yield_estimate'] = conv_df['apsim_total_std_yield_estimate'].astype(int)
+
+                conv_df.rename(columns={'apsim_matched_std_yield_estimate': 'apsim_matched_std_yield_estimate_kg_ha',
+                                        'apsim_total_std_yield_estimate': 'apsim_total_std_yield_estimate_kg_ha',}, inplace=True)
+                conv_df['region'] = region_name                                                                                                                
             else:
                 conv_df = pd.DataFrame()  # Empty DataFrame as a fallback
                 logger.warning(f"Conversion factor CSV file not found for region: {region_name}")

--- a/vercye_ops/matching_sim_real/estimate_total_yield.py
+++ b/vercye_ops/matching_sim_real/estimate_total_yield.py
@@ -55,8 +55,8 @@ def estimate_yield(tif_path, output_yield_csv_fpath, target_epsg):
     # Save total yield to CSV
     logger.info(f"Saving total yield to {output_yield_csv_fpath}")
     with open(output_yield_csv_fpath, 'w') as f:
-        pd.DataFrame({"mean_yield_kg_ha": [mean_yield],
-                      "median_yield_kg_ha": [median_yield],
+        pd.DataFrame({"mean_yield_kg_ha": int([mean_yield]),
+                      "median_yield_kg_ha": int([median_yield]),
                       "total_area_ha": [total_area_ha],
                       "total_yield_production_kg": [total_yield],
                       "total_yield_production_ton": [total_yield_tons]}).to_csv(f, index=False)

--- a/vercye_ops/matching_sim_real/estimate_total_yield.py
+++ b/vercye_ops/matching_sim_real/estimate_total_yield.py
@@ -46,16 +46,20 @@ def estimate_yield(tif_path, output_yield_csv_fpath, target_epsg):
 
     # Estimate mean yield, total area, and total yield
     mean_yield = np.nanmean(data)  # Use nansum as there are likely nodata values in the input data
+    median_yield = np.nanmedian(data)
     total_area_ha = np.sum(~np.isnan(data)) * pixel_area_ha
     total_yield = np.nansum(data * pixel_area_ha)  # Use nansum as there are likely nodata values in the input data
-    logger.info(f"Total yield: {total_yield} kg (average of {mean_yield:0.2f} kg/ha for {total_area_ha:0.2f} hectares)")
+    total_yield_tons = total_yield / 1000
+    logger.info(f"Total yield: {total_yield} kg (mean of {mean_yield:0.2f} and median of {median_yield:0.2f} kg/ha) for {total_area_ha:0.2f} hectares)")
 
     # Save total yield to CSV
     logger.info(f"Saving total yield to {output_yield_csv_fpath}")
     with open(output_yield_csv_fpath, 'w') as f:
         pd.DataFrame({"mean_yield_kg_ha": [mean_yield],
+                      "median_yield_kg_ha": [median_yield],
                       "total_area_ha": [total_area_ha],
-                      "total_yield_kg": [total_yield]}).to_csv(f, index=False)
+                      "total_yield_production_kg": [total_yield],
+                      "total_yield_production_ton": [total_yield_tons]}).to_csv(f, index=False)
 
 
 @click.command()

--- a/vercye_ops/matching_sim_real/generate_matching_report.py
+++ b/vercye_ops/matching_sim_real/generate_matching_report.py
@@ -47,10 +47,10 @@ def generate_report(apsim_filtered_fpath, rs_lai_csv_fpath, apsim_db_fpath, tota
     logger.info(f"Reading total yield/conversion factor from {total_yield_csv_fpath}")
 
     df = pd.read_csv(total_yield_csv_fpath)
-    if 'total_yield_kg' not in df.columns:
-        raise KeyError("CSV file must contain a 'total_yield_kg' column.")
+    if 'total_yield_production_kg' not in df.columns:
+        raise KeyError("CSV file must contain a 'total_yield_production_kg' column.")
 
-    total_yield_kg = df['total_yield_kg'].iloc[0]
+    total_yield_kg = df['total_yield_production_kg'].iloc[0]
     total_yield_metric_tons = total_yield_kg / 1000
     mean_yield_kg_ha = df['mean_yield_kg_ha'].round().iloc[0]
     logger.info(f"Total yield: {total_yield_kg} kg")

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -107,7 +107,7 @@ rule update_apsimx_template:
         --verbose > {log}
         """
 
-
+'''
 # Rule to run the APSIM executable (via local executable) on .apsimx files
 rule execute_simulations:
     input:
@@ -130,8 +130,8 @@ rule execute_simulations:
         --cpu-count {params.n_jobs} \
         --verbose > {log}
         """
-
 '''
+
 # Rule to run the APSIM executable (via docker) on .apsimx files
 rule execute_simulations:
     input:
@@ -151,11 +151,12 @@ rule execute_simulations:
         """
         docker run -i --rm --platform={params.docker_platform} \
         -v "{params.head_dir}:{params.head_dir}" \
+        -u $(id -u):$(id -g) \
         {params.docker_image} \
         {input} \
         --verbose > {log}
         """
-'''
+
 
 #######################################
 # S2/LAI portion of Snakemake pipeline

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -304,7 +304,6 @@ rule match_sim_real_quicklook:
         rs_stats_csv_fpath = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}_LAI_STATS.csv'),
         apsim_db_fpath = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db'),
         total_yield_csv_fpath = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}_converted_map_yield_estimate.csv'),
- 
     params:
         executable_fpath = config['scripts']['match_sim_real_quicklook'],
     log:
@@ -325,7 +324,8 @@ rule match_sim_real_quicklook:
 
 rule aggregate_yield_estimates:
     input:
-        total_yield_csvs = expand(op.join(config['sim_study_head_dir'], '{{year}}', '{{timepoint}}', '{region}', '{region}_converted_map_yield_estimate.csv'), region=config['regions'])
+        total_yield_csvs = expand(op.join(config['sim_study_head_dir'], '{{year}}', '{{timepoint}}', '{region}', '{region}_converted_map_yield_estimate.csv'), region=config['regions']),
+        conversion_factor_fpath =  expand(op.join(config['sim_study_head_dir'], '{{year}}', '{{timepoint}}', '{region}', '{region}_conversion_factor.csv'), region=config['regions'])
     params:
         executable_fpath = config['scripts']['aggregate_yield_estimates'],
         yield_dir = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}')


### PR DESCRIPTION
Closes #21 #9

### Summary

This adds a number of metrics / outputs to the aggregated yield summaries.

---

### Current Behavior
We only provide limited insights into computed values of the different regions, which is insufficient for in-depth analysis.

---

### Changes Introduced
- Added estimated median yield (kg/ha)
- Total yield in tons for better readability
- Added date for maximum remotely sensed lai
- Added insights into apsim estimates per region (max_lai, max_yield for matched and all simulations and with standard deviation)
- Rounding digits of outputs for better readability.
