### PR TITLE
Feature/generalize sim matching for croptypes

### DIFF
--- a/docs/docs/Vercye/inputs.md
+++ b/docs/docs/Vercye/inputs.md
@@ -120,7 +120,8 @@ Take a look at the [example configuration](https://github.com/JPLMLIA/vercye_ops
 - lai_params:
     - lai_dir: Root directory where remotely sensed LAI data (from the LAI pipeline) is stored 
     - lai_region: Region name, such that the files in `lai_dir` match `{region}_{date}_LAI.tif`. Use the LAI pipeline to create such files.
-    - adjustment: Adjustment applied to the remotely sensed estimated LAI. Can be either "none", "wheat", "maize"
+    - crop_name: The name of the crop for which to estimate the yield. Is related to the crop defined in APSIM. Currently "wheat" or "maize" is supprted.
+    - use_crop_adjusted_lai: Whether to apply the adjustment to the estimated remotely sensed estimated LAI. Can be either "none", "wheat", "maize". If "none" is set, no adjustment is used. Details to the adjustment formula can be found in `lai/3_analysis_LAI.py`.
     - lai_analysis_mode: 'raster'
     - time_bounds: For every year and timepoint the start and enddate from which to use LAI data. This should usually match the simulation dates.
     - crop_mask: path to the cropmasks for every year defined above.

--- a/docs/docs/Vercye/inputs.md
+++ b/docs/docs/Vercye/inputs.md
@@ -121,7 +121,7 @@ Take a look at the [example configuration](https://github.com/JPLMLIA/vercye_ops
     - lai_dir: Root directory where remotely sensed LAI data (from the LAI pipeline) is stored 
     - lai_region: Region name, such that the files in `lai_dir` match `{region}_{date}_LAI.tif`. Use the LAI pipeline to create such files.
     - crop_name: The name of the crop for which to estimate the yield. Is related to the crop defined in APSIM. Currently "wheat" or "maize" is supprted.
-    - use_crop_adjusted_lai: Whether to apply the adjustment to the estimated remotely sensed estimated LAI. Can be either "none", "wheat", "maize". If "none" is set, no adjustment is used. Details to the adjustment formula can be found in `lai/3_analysis_LAI.py`.
+    - use_crop_adjusted_lai: Whether to apply the adjustment to the estimated remotely sensed estimated LAI for the crop specified above. `True` or `False`.
     - lai_analysis_mode: 'raster'
     - time_bounds: For every year and timepoint the start and enddate from which to use LAI data. This should usually match the simulation dates.
     - crop_mask: path to the cropmasks for every year defined above.

--- a/docs/docs/Vercye/outputs.md
+++ b/docs/docs/Vercye/outputs.md
@@ -11,10 +11,10 @@ aggregated insights from multiple ROIs. In the following, we define all output a
     - Date range: APSIM simulation date range.
     - Mean yield rate: See `converted_map_yield_estimate.csv` under `mean_yield_kg_ha`.
     - Production: See `converted_map_yield_estimate.csv` under `total_yield_production_ton`.
-    - LAI filtered on step x: APSIM Simulated `Wheat.Leaf.LAI` for a specific simulation and simulation date, with the simulation being filtered out at step x, as defined in `match_sim_rs_lai.py`.
+    - LAI filtered on step x: APSIM Simulated `Wheat.Leaf.LAI` (or `Maize.Leaf.LAI`) for a specific simulation and simulation date, with the simulation being filtered out at step x, as defined in `match_sim_rs_lai.py`.
     - Yield filtered on step x: APSIM Simulated yield for a specific simulation and simulation date, with the simulation being filtered out at step x, as defined in `match_sim_rs_lai.py`. Yield in kg/ha.
     - RS mean LAI: The remotely sensed mean LAI at each date. The mean is taken over the spatial axes, so the mean of the pixel values of all pixel locations that are within the regions geometry.
-    - Mean LAI: The mean simulated LAI eat each date. Hereby the mean for each date, is computed as the mean of all matched (not-filtered out) AP-SIM simulated `Wheat.Leaf.LAI` values at that date. Yield in
+    - Mean LAI: The mean simulated LAI eat each date. Hereby the mean for each date, is computed as the mean of all matched (not-filtered out) AP-SIM simulated `Wheat.Leaf.LAI` (or `Maize.Leaf.LAI`) values at that date. Yield in
     - Mean Yield: Analogues to `Mean LAI` for the APSIM simulated yield. All simulated yield values are in kg/ha.
 - **yield_report.png**: A non-interactive snapshot with lower resolution of the `.html` yield report.
 

--- a/docs/docs/Vercye/outputs.md
+++ b/docs/docs/Vercye/outputs.md
@@ -49,16 +49,17 @@ aggregated insights from multiple ROIs. In the following, we define all output a
     - apsim_all_std_yield_estimate_kg_ha: The standard deviation in kg/ha of `Max_Yield` over all (not-filtered) APSIM simulations.
     - apsim_matched_maxlai_std: The standard LAI deviation of `Max_Sim_LAI` over the matched (filtered) APSIM simulations.
     - apsim_all_maxlai_std: The standard LAI deviation of `Max_Sim_LAI` over all (not-filtered) APSIM simulations.
-    - max_rs_lai: For each date the remotely sensed mean LAI is computed. Hereby the mean is taken spatially over the region. `max_rs_lai` then defines the maximum LAI value of these.
+    - max_rs_lai: For each date the remotely sensed mean LAI is computed (negative values clipped to 0). Hereby the mean is taken spatially over the region. `max_rs_lai` then defines the maximum LAI value of these. 
     - max_rs_lai_date: The correspinding date of the `max_rs_lai` value.
     - conversion_factor: The factor used to convert the remotely sensed LAI raster to yield estimates that are in kg/ha per pixel.
 
 
 - **LAI_STATS.csv**: Insights on the estimated LAI from the remotely sensed data.
+    Before computation all negative values are clipped to 0.
     - Date
     - n_pixels: Number of non-nan pixels in the estimated LAI raster for this date.
     - interpolated: 1 if this LAI value is interpolated based on surrounding values since no remote sensed image was available on this date. 0 it is estimated with the ML model from the remotely sensed image.
-    - LAI mean: Mean estimated LAI value over all spatial locations at this date.
+    - LAI mean: Mean estimated LAI value over all spatial locations at this date. 
     - LAI stddev: Standard deviation of LAI values over all spatial locations at this date.
     - LAI mean adjusted: Mean estimated adjsuted LAI value over all spatial locations at this date. Adjustment is used to adjust for different crops e.g maize or wheat as specified in `3_analysis_LAI.py`.
     - LAI stddev adjusted: Analogous to `LAI stddev` for the adjusted LAI.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ee
 gdal
 geopandas
 kaleido  # For static image plots in plotly
+matplotlib
 numpy
 pandas
 plotly

--- a/vercye_ops/apsim/convert_shapefile_to_geojson.py
+++ b/vercye_ops/apsim/convert_shapefile_to_geojson.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 import click
 import geopandas as gpd
@@ -66,8 +67,9 @@ def convert_shapefile_to_geojson(shp_fpath, admin_level, projection_epsg, output
         else:
             region_name = row["NAME_2"]
 
-        # Take out any apostrophes as these cause headaches down the line with scripting the filename processing
-        region_name = region_name.replace("'", "")
+        # Take out any apostrophes and other special chars as these cause headaches down the line with scripting the filename processing
+        region_name = region_name.replace("'", "").replace('"', "")
+        region_name = re.sub(r"[^\w.-]", "_", region_name)
 
         output_dir = output_head_dir / Path(region_name)
         output_dir.mkdir(exist_ok=True)

--- a/vercye_ops/lai/0_build_library.py
+++ b/vercye_ops/lai/0_build_library.py
@@ -39,8 +39,7 @@ def convert_shapefile_to_geojson(shp_fpath, admin_level, output_head_dir, verbos
     if gdf.empty:
         raise ValueError("The shapefile does not contain any polygons.")
     if gdf.crs.to_epsg() != 4326:
-        gdf = gdf.to_crs(epsg=4326)
-        #raise ValueError("The shapefile coordinate system is not WGS 84.")
+        raise ValueError("The shapefile coordinate system is not WGS 84.")
     
     if verbose:
         logging.info('Processing %i %s regions.', len(gdf), admin_level)

--- a/vercye_ops/lai/0_build_library.py
+++ b/vercye_ops/lai/0_build_library.py
@@ -4,6 +4,7 @@ import click
 import geopandas as gpd
 
 import logging
+import re
 
 logging.basicConfig(level=logging.INFO)
 
@@ -38,7 +39,8 @@ def convert_shapefile_to_geojson(shp_fpath, admin_level, output_head_dir, verbos
     if gdf.empty:
         raise ValueError("The shapefile does not contain any polygons.")
     if gdf.crs.to_epsg() != 4326:
-        raise ValueError("The shapefile coordinate system is not WGS 84.")
+        gdf = gdf.to_crs(epsg=4326)
+        #raise ValueError("The shapefile coordinate system is not WGS 84.")
     
     if verbose:
         logging.info('Processing %i %s regions.', len(gdf), admin_level)
@@ -52,8 +54,9 @@ def convert_shapefile_to_geojson(shp_fpath, admin_level, output_head_dir, verbos
         else:
             region_name = row["NAME_2"]
 
-        # Take out any apostrophes as these cause headaches down the line with scripting the filename processing
-        region_name = region_name.replace("'", "")
+        # Take out any apostrophes and other special chars as these cause headaches down the line with scripting the filename processing
+        region_name = region_name.replace("'", "").replace('"', "")
+        region_name = re.sub(r"[^\w.-]", "_", region_name)
 
         output_fpath = output_head_dir / Path(f'{region_name}.geojson')
 

--- a/vercye_ops/matching_sim_real/estimate_total_yield.py
+++ b/vercye_ops/matching_sim_real/estimate_total_yield.py
@@ -45,17 +45,21 @@ def estimate_yield(tif_path, output_yield_csv_fpath, target_epsg):
         logger.info(f"Pixel area: {pixel_area_m2:0.4f} square meters, {pixel_area_ha:0.6f} hectares")
 
     # Estimate mean yield, total area, and total yield
-    mean_yield = np.nanmean(data)  # Use nansum as there are likely nodata values in the input data
+    mean_yield = int(np.nanmean(data))  # Use nansum as there are likely nodata values in the input data
+    median_yield = int(np.nanmedian(data))
     total_area_ha = np.sum(~np.isnan(data)) * pixel_area_ha
-    total_yield = np.nansum(data * pixel_area_ha)  # Use nansum as there are likely nodata values in the input data
-    logger.info(f"Total yield: {total_yield} kg (average of {mean_yield:0.2f} kg/ha for {total_area_ha:0.2f} hectares)")
+    total_yield = int(np.nansum(data * pixel_area_ha))  # Use nansum as there are likely nodata values in the input data
+    total_yield_tons = total_yield / 1000
+    logger.info(f"Total yield: {total_yield} kg (mean of {mean_yield} and median of {median_yield} kg/ha) for {total_area_ha:0.2f} hectares)")
 
     # Save total yield to CSV
     logger.info(f"Saving total yield to {output_yield_csv_fpath}")
     with open(output_yield_csv_fpath, 'w') as f:
         pd.DataFrame({"mean_yield_kg_ha": [mean_yield],
+                      "median_yield_kg_ha": [median_yield],
                       "total_area_ha": [total_area_ha],
-                      "total_yield_kg": [total_yield]}).to_csv(f, index=False)
+                      "total_yield_production_kg": [total_yield],
+                      "total_yield_production_ton": [total_yield_tons]}).to_csv(f, index=False)
 
 
 @click.command()

--- a/vercye_ops/matching_sim_real/utils.py
+++ b/vercye_ops/matching_sim_real/utils.py
@@ -8,13 +8,16 @@ logger = get_logger()
 
 
 # Function to load simulation data from the SQLite database
-def load_simulation_data(db_path):
+def load_simulation_data(db_path, crop_name):
     """Helper to load APSIM Databases"""
+
+    crop_name = crop_name.lower()
+    crop_name = crop_name.capitalize()
 
     # Set up a connection, and extract the SQLite DB to a pandas DF
     conn = sqlite3.connect(db_path)
-    query = """
-    SELECT SimulationID, `Clock.Today`, `Clock.Today.DayOfYear`, `Wheat.Leaf.LAI`, `Yield`
+    query = f"""
+    SELECT SimulationID, `Clock.Today`, `Clock.Today.DayOfYear`, `{crop_name}.Leaf.LAI`, `Yield`
     FROM Report
     """
     df = pd.read_sql_query(query, conn, parse_dates='Clock.Today')

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -189,7 +189,7 @@ rule lai_analysis:
         lai_dir = config['lai_params']['lai_dir'],
         lai_region = config['lai_params']['lai_region'],
         mode = config['lai_params']['lai_analysis_mode'],
-        adjustment = config['lai_params']['adjustment'],
+        adjustment = config['lai_params']['crop_name'] if config['lai_params']['use_crop_adjusted_lai'] else "none",
         start_date = lambda wildcards: config['lai_params']['time_bounds'][int(wildcards.year)][wildcards.timepoint][0],
         end_date = lambda wildcards: config['lai_params']['time_bounds'][int(wildcards.year)][wildcards.timepoint][1],
     benchmark:
@@ -239,7 +239,8 @@ rule match_sim_real:
         db_fpath = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db'),
     params:
         executable_fpath = config['scripts']['match_sim_real'],
-        adjustment = "--use_adjusted" if config['lai_params']['adjustment'] != "none" else "",
+        adjustment = "--use_adjusted" if config['lai_params']['use_crop_adjusted_lai'] else "",
+        crop_name = config['lai_params']['crop_name'],
     log:
         'logs_match_sim_real/{year}_{timepoint}_{region}.log',
     output:
@@ -252,6 +253,7 @@ rule match_sim_real:
         --db_path {input.db_fpath} \
         --sim_matches_output_fpath {output.sim_matches_output_fpath} \
         --conversion_factor_output_fpath {output.conversion_factor_output_fpath} \
+        -- crop_name {params.crop_name} \
         {params.adjustment} \
         --verbose > {log}
         """
@@ -262,7 +264,7 @@ rule generate_converted_lai_map:
         conversion_factor_fpath = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}_conversion_factor.csv'),
     params:
         executable_fpath = config['scripts']['generate_converted_lai_map'],
-        adjustment = "--use_adjusted" if config['lai_params']['adjustment'] != "none" else "",  # Tells us to use first band (unadjusted) or second band (adjusted)
+        adjustment = "--use_adjusted" if config['lai_params']['use_crop_adjusted_lai'] else "",  # Tells us to use first band (unadjusted) or second band (adjusted)
     log:
         'logs_generate_converted_lai_map/{year}_{timepoint}_{region}.log',
     output:

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -253,7 +253,7 @@ rule match_sim_real:
         --db_path {input.db_fpath} \
         --sim_matches_output_fpath {output.sim_matches_output_fpath} \
         --conversion_factor_output_fpath {output.conversion_factor_output_fpath} \
-        -- crop_name {params.crop_name} \
+        --crop_name {params.crop_name} \
         {params.adjustment} \
         --verbose > {log}
         """
@@ -308,6 +308,7 @@ rule match_sim_real_quicklook:
  
     params:
         executable_fpath = config['scripts']['match_sim_real_quicklook'],
+        crop_name = config['lai_params']['crop_name'],
     log:
         'logs_match_sim_real_quicklook/{year}_{timepoint}_{region}.log',
     output:
@@ -319,6 +320,7 @@ rule match_sim_real_quicklook:
         --apsim_filtered_fpath {input.sim_matches_output_fpath} \
         --rs_lai_csv_fpath {input.rs_stats_csv_fpath} \
         --apsim_db_fpath {input.apsim_db_fpath} \
+        --crop_name {params.crop_name} \
         --total_yield_csv_fpath {input.total_yield_csv_fpath} \
         --html_fpath {output.html_fpath} \
         --png_fpath {output.png_fpath} > {log}

--- a/vercye_ops/snakemake/config_local.yaml
+++ b/vercye_ops/snakemake/config_local.yaml
@@ -112,7 +112,8 @@ apsim_execution:
 lai_params:
   lai_dir: '/Volumes/red/NASA_Ag/LAI'
   lai_region: 'Poltava'
-  adjustment: 'wheat'  # "none", "wheat", "maize"
+  crop_name: 'wheat'  # "wheat", "maize"
+  use_crop_adjusted_lai: True # If True, use crop-specific LAI adjustment. If False, use default LAI estimates
   lai_analysis_mode: 'raster'
   time_bounds: 
     2021: 

--- a/vercye_ops/snakemake/config_umd.yaml
+++ b/vercye_ops/snakemake/config_umd.yaml
@@ -114,7 +114,8 @@ apsim_execution:
 lai_params:
   lai_dir: '/gpfs/data1/cmongp2/wronk/Data/vercye_ops/LAI'
   lai_region: 'Poltava'
-  adjustment: 'wheat'  # "none", "wheat", "maize"
+  crop_name: 'wheat'  # "wheat", "maize"
+  use_crop_adjusted_lai: True # If True, use crop-specific LAI adjustment. If False, use default LAI estimates
   lai_analysis_mode: 'raster'
   time_bounds: 
     2021: 


### PR DESCRIPTION
closes #20 

---

**Current Behavior**

Currently the sim matching reads the `Wheat.Leaf.LAI` attribute from the APSIM simulation results. However, if we aim to run simulations for other croptypes, this needs to be adjusted dynamically.

---

 **Changes Introduced** 
- Now requiring to set a paramter 'crop_name' in the Snakemake configuration file. From this, the APSIM crop name is inferred. Currently supporting 'maize' and 'wheat'.
- Setting a parameter 'use_crop_adjusted_lai' to specify whether to use the corresponding crop adjusted LAI or without adjustment.

**Non-Branch related changes introduced**
- Adapted naming of regions in library creation - now escaping more special characters to avoid path operation problems.
