### PR TITLE
Per Region Target-EPSG

### DIFF
--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -271,7 +271,7 @@ rule estimate_total_yield:
         converted_lai_map = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}_yield_map.tif'),
     params:
         executable_fpath = config['scripts']['estimate_total_yield'],
-        target_epsg = config['matching_params']['target_epsg'],
+        target_epsg = lambda wildcards: config['matching_params']['target_epsgs'][wildcards.region],
     log:
         'logs_estimate_total_yield/{year}_{timepoint}_{region}.log',
     output:

--- a/vercye_ops/snakemake/config_local.yaml
+++ b/vercye_ops/snakemake/config_local.yaml
@@ -146,7 +146,34 @@ lai_params:
 # Sim/Real Matching Parameters
     
 matching_params:
-  target_epsg: 9854  # For Poltava Oblast, Ukraine. Used in pixel area calculations during yield estimation
+  # 9854 For Poltava Oblast, Ukraine. Used in pixel area calculations during yield estimation
+  target_epsgs: 
+    Chornukhynskyi: 9854
+    Chutivskyi: 9854
+    Dykanskyi: 9854
+    Hadiatskyi: 9854
+    Hlobynskyi: 9854
+    Hrebinkivskyi: 9854
+    Karlivskyi: 9854
+    Khorolskyi: 9854
+    Kobeliatskyi: 9854
+    Komsomolska: 9854
+    Kotelevskyi: 9854
+    Kozelshchynskyi: 9854
+    Kremenchutskyi: 9854
+    Lokhvytskyi: 9854
+    Lubenskyi: 9854
+    Mashivskyi: 9854
+    Myrhorodskyi: 9854
+    Novosanzharskyi: 9854
+    Orzhytskyi: 9854
+    Poltavskyi: 9854
+    Pyriatynskyi: 9854
+    Reshetylivskyi: 9854
+    Semenivskyi: 9854
+    Shyshatskyi: 9854
+    Velykobahachanskyi: 9854
+    Zinkivskyi: 9854
   
 ########################################
 # Local paths to the python/APSIM scripts

--- a/vercye_ops/snakemake/config_umd.yaml
+++ b/vercye_ops/snakemake/config_umd.yaml
@@ -146,7 +146,34 @@ lai_params:
 # Sim/Real Matching Parameters
     
 matching_params:
-  target_epsg: 9854  # For Poltava Oblast, Ukraine. Used in pixel area calculations during yield estimation
+  # 9854 For Poltava Oblast, Ukraine. Used in pixel area calculations during yield estimation
+  target_epsgs: 
+    Chornukhynskyi: 9854
+    Chutivskyi: 9854
+    Dykanskyi: 9854
+    Hadiatskyi: 9854
+    Hlobynskyi: 9854
+    Hrebinkivskyi: 9854
+    Karlivskyi: 9854
+    Khorolskyi: 9854
+    Kobeliatskyi: 9854
+    Komsomolska: 9854
+    Kotelevskyi: 9854
+    Kozelshchynskyi: 9854
+    Kremenchutskyi: 9854
+    Lokhvytskyi: 9854
+    Lubenskyi: 9854
+    Mashivskyi: 9854
+    Myrhorodskyi: 9854
+    Novosanzharskyi: 9854
+    Orzhytskyi: 9854
+    Poltavskyi: 9854
+    Pyriatynskyi: 9854
+    Reshetylivskyi: 9854
+    Semenivskyi: 9854
+    Shyshatskyi: 9854
+    Velykobahachanskyi: 9854
+    Zinkivskyi: 9854
   
 ########################################
 # Local paths to the python/APSIM scripts


### PR DESCRIPTION
**Summary**

Closes #36 
Large study areas ideally require different projections for the different regions within the study area, due to distortion. To lead to most accurate area estimates, we now require setting per-region target epsgs.

---
**Changes introduced** 
- In `snakefile configs` instead of having `matching_params. target_epsg` we now require  `matching_params. target_epsgs` with each regionname from `regions` having assigned the corresponding epsg.