### PR TITLE
Cropmask reprojection in pipeline

### DIFF
--- a/vercye_ops/apsim/fetch_met_data.py
+++ b/vercye_ops/apsim/fetch_met_data.py
@@ -174,7 +174,6 @@ def cli(start_date, end_date, variables, lon, lat, precipitation_source, chirps_
     """Wrapper to fetch_met_data"""
     if verbose:
         logger.setLevel('INFO')
-
     region = Path(output_dir).stem
     output_fpath = op.join(output_dir, f'{region}_nasapower.csv')
 

--- a/vercye_ops/lai/0_reproj_mask.py
+++ b/vercye_ops/lai/0_reproj_mask.py
@@ -1,19 +1,63 @@
 import click
+from collections import defaultdict
+from glob import glob
 
 import rasterio as rio
 from rasterio.warp import reproject, Resampling
 
 
+def find_largest_extent_LAI_file(lai_dir: str, lai_region: str):
+    lai_files = sorted(glob(f"{lai_dir}/{lai_region}*.tif"))
+    max_extent = None
+    max_extent_file = None
+    extent_frequencies = defaultdict(int)
+    for lai_file in lai_files:
+        with rio.open(lai_file) as lai_ds:
+            lai_width = lai_ds.width
+            lai_height = lai_ds.height
+
+            if max_extent is None:
+                max_extent = (lai_width, lai_height)
+                max_extent_file = lai_file
+            elif lai_width * lai_height > max_extent[0] * max_extent[1]:
+                max_extent = (lai_width, lai_height)
+                max_extent_file = lai_file
+
+            extent_frequencies[(lai_width, lai_height)] += 1
+
+    most_frequent_extent = max(extent_frequencies, key=extent_frequencies.get)
+    if most_frequent_extent != max_extent:
+        raise Exception(
+            f"LAI file with the largest extent ({max_extent_file}) is not the most frequent one. "
+            "Please manually identify which LAI file to use as a reference for resolution and extent."
+        )
+
+    return max_extent_file
+
+
 @click.command()
 @click.argument('mask_path', type=click.Path(exists=True))
-@click.argument('lai_path', type=click.Path(exists=True))
 @click.argument('out_path', type=click.Path())
-def main(mask_path, lai_path, out_path):
+@click.option('--lai_dir', type=click.Path(exists=True), default=None, help='Directory where LAI data is saved. Needs to be used with --lai_region.')
+@click.option('--lai_region', type=str, default=None)
+@click.option('--lai_path', type=click.Path(exists=True), default=None, help='Path to a specific LAI file. Mutually exclusive with --lai_dir/region.')
+def main(mask_path, out_path, lai_dir, lai_region, lai_path):
     """Reprojects a crop mask to the LAI raster
     
     mask_path is reprojected to match the projection, extent, and resolution of
     LAI_path. It is then saved as out_path.
+
+    Since the extent of LAI files may vary, it is reccomended to use --lai_dir/region to identify the file with the largest extent.
     """
+
+    if not (lai_dir and lai_region) and not lai_path:
+        raise Exception("Please either specify lai_dir and lai_region or specify lai_path.")
+
+    if (lai_dir or lai_region) and lai_path:
+        raise Exception("Please either specify lai_dir and lai_region OR lai_path.")
+
+    if lai_dir and lai_region:
+        lai_path = find_largest_extent_LAI_file(lai_dir, lai_region)
 
     with rio.open(mask_path) as mask_ds:
         # Mask's CRS

--- a/vercye_ops/lai/README.md
+++ b/vercye_ops/lai/README.md
@@ -429,19 +429,23 @@ Options:
 
 ### 0_reproj_mask.py
 
-This script reprojects a cropmask to match the CRS, resolution, and extent of a given LAI raster.
+This script reprojects a cropmask to match the CRS, resolution, and extent of a given LAI raster. It is reccomended
+to provide a LAI dir (and region), to let the script identify the maximum extent of all LAI files as these may vary.
 
 ```
 $ python 0_reproj_mask.py --help
-Usage: 0_reproj_mask.py [OPTIONS] MASK_PATH LAI_PATH OUT_PATH
+Usage: 0_reproj_mask.py [OPTIONS] MASK_PATH OUT_PATH --lai_dir --lai_region --lai_path
 
   Reprojects a crop mask to the LAI raster
 
   mask_path is reprojected to match the projection, extent, and resolution of
-  LAI_path. It is then saved as out_path.
+  LAI_path or the LAI file with the maximum extent in lai_dir matching the lai_region. It is then saved as out_path.
 
 Options:
-  --help  Show this message and exit.
+  --help          Show this message and exit.
+  --lai_dir       Base directory containing LAI files. If used, lai_region must be provided
+  --lai_region    Name of the region, used to match LAI file names. Must be used with lai_dir
+  --lai_path      Path to a specific reference LAI file. Mutually exclusive with lai_dir/region 
 ```
 
 **Example:**

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -178,6 +178,7 @@ rule execute_simulations:
             input)
     log:
         'logs_execute_simulation/{year}_{timepoint}_{region}.log',
+    threads: int(config['apsim_execution']['local']['n_jobs'])
     output:
         db_file = (
             op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.db')
@@ -195,11 +196,31 @@ rule execute_simulations:
 #######################################
 # S2/LAI portion of Snakemake pipeline
 
+# Reproject orginal cropmask to match LAI resolution
+rule reproject_cropmask:
+    input:
+        original_cropmask = lambda wildcards: config['lai_params']['crop_mask'][int(wildcards.year)],
+    params:
+        executable_fpath = config['scripts']['reproject_cropmask'],
+        lai_dir = config['lai_params']['lai_dir'],
+        lai_region = config['lai_params']['lai_region'],
+    log:
+        'logs_reproject_cropmask/{year}.log'
+    output:
+        reproj_cropmask = op.join(config['sim_study_head_dir'], '{year}', 'reprojected_cropmask.tif')
+    shell:
+        """
+        python {params.executable_fpath} \
+        {input.original_cropmask} \
+        {output.reproj_cropmask} \
+        --lai_dir {params.lai_dir} \
+        --lai_region {params.lai_region} > log
+        """
 
 # Clip the original cropmask
 rule constrain_lai_cropmask:
     input:
-        original_lai_cropmask = lambda wildcards: config['lai_params']['crop_mask'][int(wildcards.year)],  # Will need to update to time period
+        original_lai_cropmask = op.join(config['sim_study_head_dir'], '{year}', 'reprojected_cropmask.tif'),  # Will need to update to time period
         geometry_path = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}.geojson'),
     params:
         executable_fpath = config['scripts']['constrain_lai_cropmask'],

--- a/vercye_ops/snakemake/config_local.yaml
+++ b/vercye_ops/snakemake/config_local.yaml
@@ -174,3 +174,4 @@ scripts:
   aggregate_met_stats: '~/Builds/vercye_ops/vercye_ops/matching_sim_real/aggregate_meteorological_stats.py'
   evaluate_yield_estimates: '~/Builds/vercye_ops/vercye_ops/matching_sim_real/evaluate_yield_estimates.py'
   construct_chirps_data: '~/Builds/vercye_ops/vercye_ops/apsim/construct_chirps_precipitation_files.py'
+  reproject_cropmask: '~/Builds/vercye_ops/vercye_ops/lai/0_reproj_mask.py'

--- a/vercye_ops/snakemake/config_umd.yaml
+++ b/vercye_ops/snakemake/config_umd.yaml
@@ -173,3 +173,4 @@ scripts:
   aggregate_met_stats: '../matching_sim_real/aggregate_meteorological_stats.py'
   evaluate_yield_estimates: '../matching_sim_real/evaluate_yield_estimates.py'
   construct_chirps_data: '../apsim/construct_chirps_precipitation_files.py'
+  reproject_cropmask: '../lai/0_reproj_mask.py'


### PR DESCRIPTION
**Summary**
Running cropmask reprojection to target resolution from within the Vercye `snakemake` pipeline.

Closes #39 

--

**Changes introduced**

- Adapted cropmask reprojection script: Now accepting either a specific reference LAI file or accepting a directory and region name of LAI files. The second option allows automatically identifying the regional LAI file with the largest extent, since these are not necessarily the same.
- Added new rule to `snakefile`: Runs the cropmask reprojection script and uses the reprojected cropmask subsequently.