### PR TITLE
Specify GEE Export Resolution

### DIFF
--- a/docs/docs/Vercye/inputs.md
+++ b/docs/docs/Vercye/inputs.md
@@ -129,7 +129,8 @@ This file defines the study parameters and links the **simulation head directory
 
 #### LAI Parameters (`lai_params`)
 - `lai_dir`: Directory for LAI data.
-- `lai_region`: Region name with naming convention (`{region}_{date}_LAI.tif`).
+- `lai_region`: Region name with naming convention (`{region}_{date}_{resolution}m_LAI.tif`).
+- `lai_resolution`: Spatial resolutin, used for matching as above. In meters/pixel.
 - `crop_name`: Specify crop (`wheat` or `maize`). Is related to the cropname defined in APSIM.
 - `use_crop_adjusted_lai`: Adjust LAI data for the crop specified (`True`/`False`).
 - `lai_analysis_mode`: Set to `'raster'`.

--- a/vercye_ops/lai/1_1_gee_export_S2.py
+++ b/vercye_ops/lai/1_1_gee_export_S2.py
@@ -50,7 +50,8 @@ def addGeometry(image):
 @click.option('--shpfile', type=click.Path(exists=True), help='Local Path to the shapefile to override region')
 @click.option('--start-date', type=click.DateTime(formats=["%Y-%m-%d"]), help='Start date for the image collection')
 @click.option('--end-date', type=click.DateTime(formats=["%Y-%m-%d"]), help='End date for the image collection')
-def main(project, library=None, region=None, shpfile=None, start_date="2021-09-01", end_date="2021-10-01"):
+@click.option('--resolution', type=float, default=20, help='Spatial resolution in meters per pixel.')
+def main(project, library=None, region=None, shpfile=None, start_date="2021-09-01", end_date="2021-10-01", resolution=20):
 
     # Initialize Earth Engine
     ee.Initialize(project=project)
@@ -129,9 +130,9 @@ def main(project, library=None, region=None, shpfile=None, start_date="2021-09-0
         print(f"Exporting {current_datestr} to Google Drive...")
 
         task = ee.batch.Export.image.toDrive(image=S2_mosaic,
-                    description=f"{geometry_name}_{current_datestr}",
+                    description=f"{geometry_name}_{str(resolution)}m_{current_datestr}",
                     folder=geometry_name,
-                    scale=20,
+                    scale=resolution,
                     fileFormat='GeoTIFF',
                     maxPixels=1e13,
                     region=geometry,

--- a/vercye_ops/lai/1_1_gee_export_S2.py
+++ b/vercye_ops/lai/1_1_gee_export_S2.py
@@ -50,7 +50,7 @@ def addGeometry(image):
 @click.option('--shpfile', type=click.Path(exists=True), help='Local Path to the shapefile to override region')
 @click.option('--start-date', type=click.DateTime(formats=["%Y-%m-%d"]), help='Start date for the image collection')
 @click.option('--end-date', type=click.DateTime(formats=["%Y-%m-%d"]), help='End date for the image collection')
-@click.option('--resolution', type=float, default=20, help='Spatial resolution in meters per pixel.')
+@click.option('--resolution', type=int, default=20, help='Spatial resolution in meters per pixel.')
 def main(project, library=None, region=None, shpfile=None, start_date="2021-09-01", end_date="2021-10-01", resolution=20):
 
     # Initialize Earth Engine
@@ -131,7 +131,7 @@ def main(project, library=None, region=None, shpfile=None, start_date="2021-09-0
 
         task = ee.batch.Export.image.toDrive(image=S2_mosaic,
                     description=f"{geometry_name}_{str(resolution)}m_{current_datestr}",
-                    folder=geometry_name,
+                    folder=f"{geometry_name}_{str(resolution)}m",
                     scale=resolution,
                     fileFormat='GeoTIFF',
                     maxPixels=1e13,

--- a/vercye_ops/lai/1_3_standardize_S2.py
+++ b/vercye_ops/lai/1_3_standardize_S2.py
@@ -8,7 +8,8 @@ import click
 @click.argument('region', type=str)
 @click.argument('in_dir', type=click.Path(exists=True, file_okay=False))
 @click.argument('vrt_dir', type=click.Path(file_okay=False))
-def main(region, in_dir, vrt_dir):
+@click.argument('resolution', type=int)
+def main(region, in_dir, vrt_dir, resolution):
     """Generate VRTs of all region tifs in a directory
     
     Parameters
@@ -19,14 +20,15 @@ def main(region, in_dir, vrt_dir):
         Directory of region geotiffs
     vrt_dir: str
         Directory to which vrts should be written
-    
+    resolution: int
+        The resolution of the sentinel-2 images
     """
     # Create the output directory, ok if it already exists
     vrt_dir = Path(vrt_dir)
     vrt_dir.mkdir(exist_ok=True)
     
     # Get all individual files
-    downloaded_files = sorted(glob(f"{in_dir}/{region}*.tif"))
+    downloaded_files = sorted(glob(f"{in_dir}/{region}_{resolution}m*.tif"))
     print(f"Found {len(downloaded_files)}  files in {in_dir} for {region}")
 
     # Get unique dates
@@ -43,7 +45,7 @@ def main(region, in_dir, vrt_dir):
         print("Processing", date)
         # Get all the files for this date
         this_date_files = list(glob(f"{in_dir}/*{date}*.tif"))
-        out_file = vrt_dir / Path(f"{region}_{date}.vrt")
+        out_file = vrt_dir / Path(f"{region}_{resolution}m_{date}.vrt")
 
         # Build VRT
         subprocess.run(["gdalbuildvrt", out_file] + this_date_files)

--- a/vercye_ops/lai/2_primary_LAI.py
+++ b/vercye_ops/lai/2_primary_LAI.py
@@ -47,18 +47,24 @@ class LAI_CNN(nn.Module):
 @click.command()
 @click.argument('S2_dir', type=click.Path(exists=True))
 @click.argument('LAI_dir', type=click.Path(exists=True))
+@click.argument('region', type=str)
+@click.argument('resolution', type=int)
 @click.option('--model_weights', type=click.Path(exists=True), default='models/s2_sl2p_weiss_or_prosail_NNT3_Single_0_1_LAI.pth', help='Local Path to the model weights')
-def main(s2_dir, lai_dir, model_weights="models/s2_sl2p_weiss_or_prosail_NNT3_Single_0_1_LAI.pth"):
+def main(s2_dir, lai_dir, region, resolution, model_weights="models/s2_sl2p_weiss_or_prosail_NNT3_Single_0_1_LAI.pth"):
     """ Main LAI batch prediction function
 
-    S2_dir: Local Path to the Sentinel-2 images
+    S2_dir: Local Path to the .vrt Sentinel-2 images
 
     LAI_dir: Local Path to the LAI estimates
 
+    region: Name of the region. Used to match file names beginning with region_
+
+    resolution: Spatial resolution. Used to match file names beginning with region_resolution
+
     This pipeline does the following:
-    1. Looks for Sentinel-2 images in the specified directory in the format {geometry_name}_{date}.vrt
+    1. Looks for Sentinel-2 images in the specified directory in the format {geometry_name}_{resolution}m_{date}.vrt
     2. Uses the pytorch model to predict LAI
-    3. Exports the LAI estimate to the specified directory in the format {geometry_name}_{date}_LAI.tif
+    3. Exports the LAI estimate to the specified directory in the format {geometry_name}_{resolution}m_{date}_LAI.tif
     """
 
     start = time.time()
@@ -69,8 +75,8 @@ def main(s2_dir, lai_dir, model_weights="models/s2_sl2p_weiss_or_prosail_NNT3_Si
     model.eval()
 
     # Get all the VRT files
-    vrt_files = sorted(glob(f"{s2_dir}/*.vrt"))
-    print(f"Found {len(vrt_files)} VRT files in {s2_dir}")
+    vrt_files = sorted(glob(f"{s2_dir}/{region}_{resolution}m_*.vrt"))
+    print(f"Found {len(vrt_files)} VRT files for {region} at {resolution}m in {s2_dir}")
 
     for vf in vrt_files:
         # Load the image

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -178,6 +178,7 @@ rule lai_analysis:
         executable_fpath = config['scripts']['lai_analysis'],
         lai_dir = config['lai_params']['lai_dir'],
         lai_region = config['lai_params']['lai_region'],
+        lai_resolution = config['lai_params']['lai_resolution'],
         mode = config['lai_params']['lai_analysis_mode'],
         adjustment = config['lai_params']['crop_name'] if config['lai_params']['use_crop_adjusted_lai'] else "none",
         start_date = lambda wildcards: config['lai_params']['time_bounds'][int(wildcards.year)][wildcards.timepoint][0],
@@ -196,6 +197,7 @@ rule lai_analysis:
         {output.stats_csv} \
         {output.max_lai_tif} \
         {params.lai_region} \
+        {params.lai_resolution} \
         {input.constrained_cropmask} \
         --mode {params.mode} \
         --adjustment {params.adjustment} \

--- a/vercye_ops/snakemake/config_local.yaml
+++ b/vercye_ops/snakemake/config_local.yaml
@@ -122,6 +122,7 @@ keep_apsim_db_files: True
 lai_params:
   lai_dir: '/Volumes/red/NASA_Ag/LAI'
   lai_region: 'Poltava'
+  lai_resolution: 20 # meters/pixel
   crop_name: 'wheat'  # "wheat", "maize"
   use_crop_adjusted_lai: True # If True, use crop-specific LAI adjustment. If False, use default LAI estimates
   lai_analysis_mode: 'raster'

--- a/vercye_ops/snakemake/config_umd.yaml
+++ b/vercye_ops/snakemake/config_umd.yaml
@@ -122,6 +122,7 @@ keep_apsim_db_files: True
 lai_params:
   lai_dir: '/gpfs/data1/cmongp2/wronk/Data/vercye_ops/LAI'
   lai_region: 'Poltava'
+  lai_resolution: 20 # meters/pixel
   crop_name: 'wheat'  # "wheat", "maize"
   use_crop_adjusted_lai: True # If True, use crop-specific LAI adjustment. If False, use default LAI estimates
   lai_analysis_mode: 'raster'


### PR DESCRIPTION
**Summary**

For different analysis tasks we require sentinel-2 data at different scale. Now allowing to specify the resolution.

Closes #48 

--

**Changes Introduced**
- Added cli parameter for resolution in `lai/1_1_gee_export.py`
- Adding resolution to all other lai-related scripts, to allow having all files in a same folder and matching by `{regionname}_{resolution}m}_*`
- Adding region (and resolution) parameter to `primary_LAI` generation script -> Allowing finer grained execution on a folder containing different regions/resolution.
- Adding `lai_resolution` parameter to snakemake configs, to ensure LAI is only analyzed for the corresponding resolution. 