### PR TITLE
Auto reproject shapefiles

### DIFF
--- a/vercye_ops/apsim/convert_shapefile_to_geojson.py
+++ b/vercye_ops/apsim/convert_shapefile_to_geojson.py
@@ -47,7 +47,8 @@ def convert_shapefile_to_geojson(shp_fpath, admin_level, projection_epsg, output
     if gdf.empty:
         raise ValueError("The shapefile does not contain any polygons.")
     if gdf.crs.to_epsg() != 4326:
-        raise ValueError("The shapefile coordinate system is not WGS 84.")
+        logger.warning("Shapefile not in WGS84. Reprojecting.")
+        gdf = gdf.to_crs(epsg=4326)
     
     # Add a new column for the centroid of each polygon
     gdf_proj = gdf.to_crs(epsg=projection_epsg)  # Calculate this in flattened projection instead of geodesic space

--- a/vercye_ops/lai/0_build_library.py
+++ b/vercye_ops/lai/0_build_library.py
@@ -39,7 +39,8 @@ def convert_shapefile_to_geojson(shp_fpath, admin_level, output_head_dir, verbos
     if gdf.empty:
         raise ValueError("The shapefile does not contain any polygons.")
     if gdf.crs.to_epsg() != 4326:
-        raise ValueError("The shapefile coordinate system is not WGS 84.")
+        print("Shapefile not in WGS84. Reprojecting.")
+        gdf = gdf.to_crs(epsg=4326)
     
     if verbose:
         logging.info('Processing %i %s regions.', len(gdf), admin_level)


### PR DESCRIPTION
**Summary**
Automatically reprojecting shapefiles to WGS84 during shapefile->geojson conversion. Reduces manual effort. So far we required the files to be in WGS84 or otherwise would raise an Error.

closes #46 

---

**Changes Introduces**
- Automatical reprojection to `epsg 4326` in `convert_shapefile_to_geojson.py` and `0_build_library.py`, with logging to give user feedback on this.
