### PR TITLE
Feature: Allow any CRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ mkdir -p ~/Data/vercye_ops/Ukraine_Admin_Units/simstudy_20240607/2021/T-0
 # Set the `admin_level` to "oblast" or "raion" if there are two levels in the shapefile
 python ~/Builds/vercye_ops/vercye_ops/apsim/convert_shapefile_to_geojson.py \
 --shp_fpath /path/to/UKR_adm1.shp \
---admin_level oblast
+--admin_level oblast \
+----projection_crs "EPSG:6381" \
 --output_head_dir ~/Data/vercye_ops/Ukraine_Admin_Units/simstudy_20240607/2021/T-0 \
 --verbose
 ```

--- a/docs/docs/Vercye/inputs.md
+++ b/docs/docs/Vercye/inputs.md
@@ -138,7 +138,7 @@ This file defines the study parameters and links the **simulation head directory
 - `crop_mask`: Path to crop mask files for each year.
 
 #### Matching Parameters (`matching_params`)
-- `target_epsg`: EPSG code for coordinate reference system used for area calculation. Should be choosen with care to minimize distortions.
+- `target_crs`: CRS string for coordinate reference system used for area calculation. Either a proj string (e.g `'"+proj=aea +lat_1=29 +lat_2=36 +lat_0=32.5 +lon_0=-5 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs"'`) or authority string (e.g `'epsg:1234'`). Should be choosen with care to minimize distortions. If using a proj string ensure to encolose it with additional quotes as in the example.
 
 #### APSIM Execution (`apsim_execution`)
 - `use_docker`: Set `True` to run APSIM in Docker.

--- a/vercye_ops/matching_sim_real/estimate_total_yield.py
+++ b/vercye_ops/matching_sim_real/estimate_total_yield.py
@@ -11,7 +11,7 @@ from vercye_ops.utils.init_logger import get_logger
 logger = get_logger()
 
 
-def estimate_yield(tif_path, output_yield_csv_fpath, target_epsg):
+def estimate_yield(tif_path, output_yield_csv_fpath, target_crs):
     """
     Estimate total yield from a converted LAI geotiff file.
 
@@ -21,8 +21,8 @@ def estimate_yield(tif_path, output_yield_csv_fpath, target_epsg):
         Filepath to the input converted LAI geotiff file.
     output_yield_csv_fpath : str
         Filepath where the total yield will be saved as a CSV file.
-    target_epsg : int
-        EPSG code of the project target coordinate system.
+    target_crs : str
+        CRS string of the project target coordinate system.
     """
     logger.info(f"Opening geotiff file {tif_path}")
     with rasterio.open(tif_path) as src:
@@ -38,7 +38,7 @@ def estimate_yield(tif_path, output_yield_csv_fpath, target_epsg):
 
         pixel_width_deg, pixel_height_deg = src.transform[0], np.abs(src.transform[4])
 
-        pixel_area_m2 = compute_pixel_area(center_lon, center_lat, pixel_width_deg, pixel_height_deg, target_epsg)
+        pixel_area_m2 = compute_pixel_area(center_lon, center_lat, pixel_width_deg, pixel_height_deg, target_crs)
         pixel_area_ha = pixel_area_m2 / 10000
 
         # For debugging purposes
@@ -65,17 +65,17 @@ def estimate_yield(tif_path, output_yield_csv_fpath, target_epsg):
 
 @click.command()
 @click.option('--converted_lai_tif_fpath', required=True, type=click.Path(exists=True), help='Filepath to the input converted LAI geotiff file.')
-@click.option('--target_epsg', required=True, type=int, help='EPSG code of the project target coordinate system (used for pixel area calculation).')
+@click.option('--target_crs', required=True, type=str, help='CRS ("EPSG:XXXX" or proj string) of the project target coordinate system (used for pixel area calculation).')
 @click.option('--output_yield_csv_fpath', required=True, type=click.Path(), help='Filepath where the total yield will be saved as a CSV file.')
 @click.option('--verbose', is_flag=True, help='Enable verbose logging.')
-def cli(converted_lai_tif_fpath, output_yield_csv_fpath, target_epsg, verbose):
+def cli(converted_lai_tif_fpath, output_yield_csv_fpath, target_crs, verbose):
     """CLI for estimating total yield from a converted LAI geotiff file."""
 
     # Configure logging
     logging_level = logging.INFO if verbose else logging.WARNING
     logger.setLevel(logging_level)
 
-    estimate_yield(converted_lai_tif_fpath, output_yield_csv_fpath, target_epsg)
+    estimate_yield(converted_lai_tif_fpath, output_yield_csv_fpath, target_crs)
 
 if __name__ == '__main__':
     cli()

--- a/vercye_ops/matching_sim_real/utils.py
+++ b/vercye_ops/matching_sim_real/utils.py
@@ -46,11 +46,11 @@ def load_simulation_units(db_path):
     return df
 
 
-def compute_pixel_area(lon, lat, pixel_width_deg, pixel_height_deg, output_epsg, input_epsg=4326):
+def compute_pixel_area(lon, lat, pixel_width_deg, pixel_height_deg, output_crs, input_crs='EPSG:4326'):
     """Compute the area of a pixel in square meters given a latitude and pixel size in degrees"""
 
     # Create a transformer object
-    transformer = Transformer.from_crs(input_epsg, output_epsg, always_xy=True)
+    transformer = Transformer.from_crs(input_crs, output_crs, always_xy=True)
     
     # Convert the corners of the pixel to Web Mercator
     x1, y1 = transformer.transform(lon, lat)

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -276,7 +276,7 @@ rule estimate_total_yield:
         converted_lai_map = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}_yield_map.tif'),
     params:
         executable_fpath = config['scripts']['estimate_total_yield'],
-        target_epsg = config['matching_params']['target_epsg'],
+        target_crsg = config['matching_params']['target_crsg'],
     log:
         'logs_estimate_total_yield/{year}_{timepoint}_{region}.log',
     output:
@@ -285,7 +285,7 @@ rule estimate_total_yield:
         """
         python {params.executable_fpath} \
         --converted_lai_tif_fpath {input.converted_lai_map} \
-        --target_epsg {params.target_epsg} \
+        --target_crsg {params.target_crsg} \
         --output_yield_csv_fpath {output.total_yield_csv} \
         --verbose > {log}
         """

--- a/vercye_ops/snakemake/config_local.yaml
+++ b/vercye_ops/snakemake/config_local.yaml
@@ -147,7 +147,7 @@ lai_params:
 # Sim/Real Matching Parameters
     
 matching_params:
-  target_epsg: 9854  # For Poltava Oblast, Ukraine. Used in pixel area calculations during yield estimation
+  target_crs: 'EPSG:9854'  # For Poltava Oblast, Ukraine. Used in pixel area calculations during yield estimation
   
 ########################################
 # Local paths to the python/APSIM scripts

--- a/vercye_ops/snakemake/config_umd.yaml
+++ b/vercye_ops/snakemake/config_umd.yaml
@@ -147,7 +147,7 @@ lai_params:
 # Sim/Real Matching Parameters
     
 matching_params:
-  target_epsg: 9854  # For Poltava Oblast, Ukraine. Used in pixel area calculations during yield estimation
+  target_crs: 'EPSG:9854'  # For Poltava Oblast, Ukraine. Used in pixel area calculations during yield estimation
   
 ########################################
 # Local paths to the python/APSIM scripts


### PR DESCRIPTION
**Summary**
Instead of having an epsg input, users can now specify any CRS for example as a `proj` string. This allow more flexibility for local adaptions.

**Changes introduced**
- `matching_params.target_epsg` in config renamed to `matching_params.target_crs`. If using a epsg code, now explicitly requiring setting the value as `"EPSG:1234"`.
- Using crs param instead of epsg param for reprojections in shapefile conversion and yield estimation.

**ToDo**
- [x] Update documentation