### PR TITLE
[Draft] NASAPower Caching. Avoid ratelimiting.

### DIFF
--- a/vercye_ops/apsim/fetch_met_data.py
+++ b/vercye_ops/apsim/fetch_met_data.py
@@ -153,7 +153,7 @@ def get_nasapower_cachefile_path(lon, lat, cache_dir):
     return cachefile_path
 
 
-def get_nasa_power_data(start_date, end_date, variables, lon, lat, output_fpath, overwrite, cache_dir=None):
+def get_nasa_power_data(start_date, end_date, variables, lon, lat, output_fpath, cache_dir, overwrite):
     """
     Fetches weather data from the NASA POWER API for a given latitude and longitude between 
     start_date and end_date if not already present in the output_dir.
@@ -248,18 +248,16 @@ def save_to_cache(df, lon, lat, cache_dir):
 @click.option('--chirps_column_name', default=None, help="Name of the region (ROI) must match a column in the CHIRPS file if used.")
 @click.option('--fallback_nasapower', help="Fallback to NASA POWER data if CHIRPS data is not available.", default=False)
 @click.option('--chirps_file', type=click.Path(file_okay=True, dir_okay=False), default=None, help="File where the CHIRPS extracted chirps-data is saved.")
-@click.option('--output_dir', type=click.Path(file_okay=False, dir_okay=True, writable=True), required=True, help="Directory where the .csv file will be saved.")
+@click.option('--output_fpath', type=click.Path(file_okay=True, dir_okay=False, writable=True), required=True, help="Path of the .csv file that will be saved.")
 @click.option('--cache_dir', type=click.Path(file_okay=False, dir_okay=True, writable=True), required=False, help="Directory where nasapower data can be cached and will be indexed by nasapower pixelID.")
 @click.option('--overwrite', is_flag=True, help="Enable file overwriting if weather data already exists.")
 @click.option('--verbose', is_flag=True, help="Enable verbose logging.")
-def cli(start_date, end_date, variables, lon, lat, precipitation_source, chirps_column_name, fallback_nasapower, chirps_file, output_dir, cache_dir, overwrite, verbose):
+def cli(start_date, end_date, variables, lon, lat, precipitation_source, chirps_column_name, fallback_nasapower, chirps_file, output_fpath, cache_dir, overwrite, verbose):
     """Wrapper to fetch_met_data"""
     if verbose:
         logger.setLevel('INFO')
-    region = Path(output_dir).stem
-    output_fpath = op.join(output_dir, f'{region}_nasapower.csv')
 
-    df = get_nasa_power_data(start_date, end_date, variables, lon, lat, output_dir, overwrite)
+    df = get_nasa_power_data(start_date, end_date, variables, lon, lat, output_fpath, cache_dir, overwrite)
 
     if precipitation_source.lower() == 'chirps':
         try:

--- a/vercye_ops/snakemake/Snakefile
+++ b/vercye_ops/snakemake/Snakefile
@@ -68,7 +68,8 @@ rule fetch_met_data:
         jq_load_statement = 'module load jq' if config['platform'] == 'umd' else '',
         region_name = lambda wildcards: wildcards.region,
         chirps_file = lambda wildcards: f"--chirps_file {op.join(config['sim_study_head_dir'], 'temporary_chirps', f'{wildcards.year}_{wildcards.timepoint}.parquet')}" if config['apsim_params']['precipitation_source'].lower() == 'chirps' else ''
-    log: 
+        met_cache_dir = config['apsim_params']['met_cache_dir'] if config['apsim_params']['met_cache_dir'] else temp(op.join(config['sim_study_head_dir'], 'met_cache'))
+    log:
         'logs_fetch_met_data/{year}_{timepoint}_{region}.log',
     output:
         csv = op.join(config['sim_study_head_dir'], '{year}', '{timepoint}', '{region}', '{region}_nasapower.csv'),
@@ -93,7 +94,8 @@ rule fetch_met_data:
         --chirps_column_name {params.region_name} \
         --fallback_nasapower {params.fallback_nasapower} \
         {params.chirps_file} \
-        --output_dir {params.head_dir}/{wildcards.year}/{wildcards.timepoint}/{wildcards.region}/ \
+        --output_fpath {output.csv} \
+        --cache_dir {params.met_cache_dir} \
         --overwrite \
         --verbose > {log}
         """

--- a/vercye_ops/snakemake/config_local.yaml
+++ b/vercye_ops/snakemake/config_local.yaml
@@ -58,6 +58,7 @@ apsim_params:
   precipitation_agg_method: 'centroid' # 'mean' or 'centroid'. Mean is currently only supported for CHIRPS.
   fallback_on_nasa_power_centroid: False # If True, will use NASA POWER precipitation data if region is out of bounds for CHIRPS data. Please be aware that changing this might make the precipitation data inconsistent.
   chirps_dir: '/home/rohan/nasa-harvest/vercye/data/chirps' # Only required to set if precipitation_source is 'CHIRPS'
+  met_cache_dir: '' # Directory to store met data for multiple yield studies. If empty, will use a temp store for each study.
   time_bounds:
     2021:
       T-0:


### PR DESCRIPTION
**Summary**
We are currently being ratelimited from NASAPower during requesting of the meteorological data. To avoid this in the future, we should not request data that was already previously requested during a yield study.

For this, we introduce a cache that maps each ROI to a the centroid of a NasaPower gridcell and before requesting the met data for a ROI checks if it is present in the cache and only queries missing dates.

closes #34 

**Changes Introduced**

**ToDO**
- [ ] Identify how to best match ROI centroid coordinates to NASAPower grid cells. 
- [x] Add to Snakemake Pipeline